### PR TITLE
Fix bug in counting number of workspaces

### DIFF
--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -962,14 +962,14 @@ class WorkspaceReportTest(TestCase):
 
     def test_workspace_count_table_one_workspace_shared_twice(self):
         """Workspace table includes correct values for one workspace  that has been shared twice."""  # noqa: E501
-        upload_workspace = factories.UploadWorkspaceFactory.create()
+        upload_workspace_1 = factories.UploadWorkspaceFactory.create()
         # Create the sharing record with GREGOR_ALL.
         acm_factories.WorkspaceGroupSharingFactory.create(
-            workspace=upload_workspace.workspace, group__name="GREGOR_ALL"
+            workspace=upload_workspace_1.workspace, group__name="GREGOR_ALL"
         )
         # Create a sharing record with another group.
         acm_factories.WorkspaceGroupSharingFactory.create(
-            workspace=upload_workspace.workspace
+            workspace=upload_workspace_1.workspace
         )
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())

--- a/gregor_django/gregor_anvil/views.py
+++ b/gregor_django/gregor_anvil/views.py
@@ -62,7 +62,7 @@ class WorkspaceReport(AnVILConsortiumManagerViewRequired, TemplateView):
             verified_email_entry__date_verified__isnull=False
         ).count()
         qs = Workspace.objects.values("workspace_type").annotate(
-            n_total=Count("workspace_type", distinct=True),
+            n_total=Count("pk", distinct=True),
             n_shared=Count(
                 "workspacegroupsharing",
                 filter=Q(workspacegroupsharing__group__name="GREGOR_ALL"),


### PR DESCRIPTION
When a workspace was shared with GREGOR_ALL plus another group, the workspace was counted extra times. I think this was from the join with the WorkspaceGroupSharing model. Add the distinct keyword to the Count method when counting the total number of workspaces.