### PR TITLE
Update custom workspace data tables

### DIFF
--- a/gregor_django/gregor_anvil/adapters.py
+++ b/gregor_django/gregor_anvil/adapters.py
@@ -1,6 +1,5 @@
 from anvil_consortium_manager.adapters.account import BaseAccountAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
-from anvil_consortium_manager.tables import WorkspaceTable
 from django.db.models import Q
 
 from . import forms, models, tables
@@ -45,7 +44,7 @@ class ExampleWorkspaceAdapter(BaseWorkspaceAdapter):
     description = (
         "Workspaces that contain examples of using AnVIL, working with data, etc."
     )
-    list_table_class = WorkspaceTable
+    list_table_class = tables.DefaultWorkspaceTable
     workspace_data_model = models.ExampleWorkspace
     workspace_data_form_class = forms.ExampleWorkspaceForm
     workspace_detail_template_name = "anvil_consortium_manager/workspace_detail.html"
@@ -69,7 +68,7 @@ class CombinedConsortiumDataWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "combined_consortium"
     name = "Combined consortium data workspace"
     description = "Workspaces for internal consortium use that contain data tables combined across upload workspaces"
-    list_table_class = WorkspaceTable
+    list_table_class = tables.DefaultWorkspaceTable
     workspace_data_model = models.CombinedConsortiumDataWorkspace
     workspace_data_form_class = forms.CombinedConsortiumDataWorkspaceForm
     workspace_detail_template_name = (

--- a/gregor_django/gregor_anvil/tables.py
+++ b/gregor_django/gregor_anvil/tables.py
@@ -1,6 +1,7 @@
 import django_tables2 as tables
 from anvil_consortium_manager.adapters.workspace import workspace_adapter_registry
 from anvil_consortium_manager.models import Account, Workspace
+from django.utils.html import format_html
 
 from . import models
 
@@ -46,7 +47,54 @@ class ConsentGroupTable(tables.Table):
         )
 
 
-class UploadWorkspaceTable(tables.Table):
+class WorkspaceSharedWithConsortiumTable(tables.Table):
+    """Table including a column to indicate if a workspace is shared with PRIMED_ALL."""
+
+    is_shared = tables.columns.Column(
+        accessor="pk",
+        verbose_name="Shared with GREGoR?",
+        orderable=False,
+    )
+
+    def render_is_shared(self, record):
+        is_shared = record.workspacegroupsharing_set.filter(
+            group__name="GREGOR_ALL"
+        ).exists()
+        if is_shared:
+            icon = "check-circle-fill"
+            color = "green"
+            value = format_html(
+                """<i class="bi bi-{}" style="color: {};"></i>""".format(icon, color)
+            )
+        else:
+            value = ""
+        return value
+
+
+class DefaultWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
+    """Class to use for default workspace tables in GREGoR."""
+
+    name = tables.Column(linkify=True, verbose_name="Workspace")
+    billing_project = tables.Column(linkify=True)
+    number_groups = tables.Column(
+        verbose_name="Number of groups shared with",
+        empty_values=(),
+        orderable=False,
+        accessor="workspacegroupsharing_set__count",
+    )
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "name",
+            "billing_project",
+            "number_groups",
+            "is_shared",
+        )
+        order_by = ("name",)
+
+
+class UploadWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
     """A table for Workspaces that includes fields from UploadWorkspace."""
 
     name = tables.columns.Column(linkify=True)
@@ -58,10 +106,11 @@ class UploadWorkspaceTable(tables.Table):
             "uploadworkspace__research_center",
             "uploadworkspace__consent_group",
             "uploadworkspace__version",
+            "is_shared",
         )
 
 
-class TemplateWorkspaceTable(tables.Table):
+class TemplateWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
     """A table for Workspaces that includes fields from TemplateWorkspace."""
 
     name = tables.columns.Column(linkify=True)
@@ -71,6 +120,7 @@ class TemplateWorkspaceTable(tables.Table):
         fields = (
             "name",
             "templateworkspace__intended_use",
+            "is_shared",
         )
 
 

--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -2,7 +2,6 @@ import json
 
 import responses
 from anvil_consortium_manager import models as acm_models
-from anvil_consortium_manager.tables import WorkspaceTable
 from anvil_consortium_manager.tests import factories as acm_factories
 from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
 from django.conf import settings
@@ -653,7 +652,9 @@ class ExampleWorkspaceListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.workspace_type))
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], WorkspaceTable)
+        self.assertIsInstance(
+            response.context_data["table"], tables.DefaultWorkspaceTable
+        )
 
 
 class ExampleWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):


### PR DESCRIPTION
- Add a custom django-tables2 subclass that has a column: whether the workspace is shared with GREGOR_ALL.
- Add a default workspace data table for workspace adapters that don't define their own table class.
- Use the table subclass to add the shared with GREGOR column to workspace adapter tables that do define their own table class.