### PR TITLE
Update WorkspaceSharedWIthConsortiumTable for new sharing strategy

### DIFF
--- a/gregor_django/gregor_anvil/tables.py
+++ b/gregor_django/gregor_anvil/tables.py
@@ -80,26 +80,26 @@ class UploadCycleTable(tables.Table):
         return str(record)
 
 
-class WorkspaceSharedWithConsortiumTable(tables.Table):
+class WorkspaceConsortiumAccessTable(tables.Table):
     """Table including a column to indicate if a workspace is shared with PRIMED_ALL."""
 
-    is_shared = tables.columns.Column(
+    consortium_access = tables.columns.Column(
         accessor="pk",
-        verbose_name="Shared with GREGoR?",
+        verbose_name="Consortium access?",
         orderable=False,
     )
 
-    def render_is_shared(self, record):
+    def render_consortium_access(self, record):
         try:
             group = ManagedGroup.objects.get(name="GREGOR_ALL")
         except ManagedGroup.DoesNotExist:
-            is_shared = False
+            has_consortium_access = False
         else:
-            is_shared = record.is_in_authorization_domain(group) and record.is_shared(
+            has_consortium_access = record.is_in_authorization_domain(
                 group
-            )
+            ) and record.is_shared(group)
 
-        if is_shared:
+        if has_consortium_access:
             icon = "check-circle-fill"
             color = "green"
             value = format_html(
@@ -110,7 +110,7 @@ class WorkspaceSharedWithConsortiumTable(tables.Table):
         return value
 
 
-class DefaultWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
+class DefaultWorkspaceTable(WorkspaceConsortiumAccessTable, tables.Table):
     """Class to use for default workspace tables in GREGoR."""
 
     name = tables.Column(linkify=True, verbose_name="Workspace")
@@ -128,12 +128,12 @@ class DefaultWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
             "name",
             "billing_project",
             "number_groups",
-            "is_shared",
+            "consortium_access",
         )
         order_by = ("name",)
 
 
-class UploadWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
+class UploadWorkspaceTable(WorkspaceConsortiumAccessTable, tables.Table):
     """A table for Workspaces that includes fields from UploadWorkspace."""
 
     name = tables.columns.Column(linkify=True)
@@ -146,11 +146,11 @@ class UploadWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
             "uploadworkspace__upload_cycle",
             "uploadworkspace__research_center",
             "uploadworkspace__consent_group",
-            "is_shared",
+            "consortium_access",
         )
 
 
-class TemplateWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
+class TemplateWorkspaceTable(WorkspaceConsortiumAccessTable, tables.Table):
     """A table for Workspaces that includes fields from TemplateWorkspace."""
 
     name = tables.columns.Column(linkify=True)
@@ -160,7 +160,7 @@ class TemplateWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
         fields = (
             "name",
             "templateworkspace__intended_use",
-            "is_shared",
+            "consortium_access",
         )
 
 
@@ -183,7 +183,7 @@ class WorkspaceReportTable(tables.Table):
 
 
 class CombinedConsortiumDataWorkspaceTable(
-    WorkspaceSharedWithConsortiumTable, tables.Table
+    WorkspaceConsortiumAccessTable, tables.Table
 ):
     """A table for Workspaces that includes fields from CombinedConsortiumDataWorkspace."""
 
@@ -230,7 +230,7 @@ class DCCProcessingWorkspaceTable(tables.Table):
         )
 
 
-class DCCProcessedDataWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
+class DCCProcessedDataWorkspaceTable(WorkspaceConsortiumAccessTable, tables.Table):
     """A table for Workspaces that includes fields from DCCProcessedDataWorkspace."""
 
     name = tables.columns.Column(linkify=True)
@@ -242,5 +242,5 @@ class DCCProcessedDataWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.
             "name",
             "dccprocesseddataworkspace__upload_cycle",
             "dccprocesseddataworkspace__consent_group",
-            "is_shared",
+            "consortium_access",
         )

--- a/gregor_django/gregor_anvil/tests/test_tables.py
+++ b/gregor_django/gregor_anvil/tests/test_tables.py
@@ -117,7 +117,7 @@ class UploadCycleTableTest(TestCase):
         self.assertEqual(len(table.rows), 2)
 
 
-class WorkspaceSharedWithConsortiumTableTest(TestCase):
+class WorkspaceConsortiumAccessTableTest(TestCase):
     """Tests for the is_shared column."""
 
     def setUp(self):
@@ -126,29 +126,29 @@ class WorkspaceSharedWithConsortiumTableTest(TestCase):
     def test_is_shared_no_auth_domain_not_shared(self):
         """Workspace has no auth domain and is not shared with GREGOR_ALL."""
         workspace = WorkspaceFactory.create()
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_no_auth_domain_shared(self):
         """Workspace has no auth domain and is shared with GREGOR_ALL."""
         workspace = WorkspaceFactory.create()
         WorkspaceGroupSharingFactory.create(workspace=workspace, group=self.gregor_all)
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_no_auth_domain_shared_other_group(self):
         """Workspace has no auth domain and is shared with a different group."""
         workspace = WorkspaceFactory.create()
         WorkspaceGroupSharingFactory.create(workspace=workspace)
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_not_shared_not_in_auth_domain(self):
         """GREGOR_ALL is not in auth domain and workspace is not shared."""
         workspace = WorkspaceFactory.create()
         WorkspaceAuthorizationDomainFactory.create(workspace=workspace)
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_not_shared_in_auth_domain(self):
         """GREGOR_ALL is in auth domain and workspace is not shared."""
@@ -157,8 +157,8 @@ class WorkspaceSharedWithConsortiumTableTest(TestCase):
         GroupGroupMembershipFactory.create(
             parent_group=auth_domain.group, child_group=self.gregor_all
         )
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_shared_different_group_in_auth_domain(self):
         """GREGOR_ALL is in auth domain and workspace is shared with a different group."""
@@ -168,16 +168,16 @@ class WorkspaceSharedWithConsortiumTableTest(TestCase):
             parent_group=auth_domain.group, child_group=self.gregor_all
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace)
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_shared_with_gregor_all_not_in_auth_domain(self):
         """GREGOR_ALL is not in auth domain and workspace is shared with GREGOR_ALL."""
         workspace = WorkspaceFactory.create()
         WorkspaceAuthorizationDomainFactory.create(workspace=workspace)
         WorkspaceGroupSharingFactory.create(workspace=workspace, group=self.gregor_all)
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_shared_with_auth_domain_not_in_auth_domain(self):
         """GREGOR_ALL is not in auth domain and workspace is shared with its auth domain."""
@@ -186,8 +186,8 @@ class WorkspaceSharedWithConsortiumTableTest(TestCase):
         WorkspaceGroupSharingFactory.create(
             workspace=workspace, group=auth_domain.group
         )
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_shared_with_gregor_all_in_auth_domain(self):
         """GREGOR_ALL is in auth domain and workspace is shared with GREGOR_ALL."""
@@ -197,8 +197,8 @@ class WorkspaceSharedWithConsortiumTableTest(TestCase):
             parent_group=auth_domain.group, child_group=self.gregor_all
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace, group=self.gregor_all)
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_shared_with_auth_domain_in_auth_domain(self):
         """GREGOR_ALL is in auth domain and workspace is shared with its auth domain."""
@@ -210,8 +210,8 @@ class WorkspaceSharedWithConsortiumTableTest(TestCase):
         WorkspaceGroupSharingFactory.create(
             workspace=workspace, group=auth_domain.group
         )
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertIn("check-circle-fill", table.render_consortium_access(workspace))
 
     def test_is_shared_one_auth_domain_shared_with_different_group_in_auth_domain(self):
         """GREGOR_ALL is in auth domain and workspace is shared with a different group."""
@@ -221,8 +221,8 @@ class WorkspaceSharedWithConsortiumTableTest(TestCase):
             parent_group=auth_domain.group, child_group=self.gregor_all
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace)
-        table = tables.WorkspaceSharedWithConsortiumTable(Workspace.objects.all())
-        self.assertNotIn("check-circle-fill", table.render_is_shared(workspace))
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
 
 class UploadWorkspaceTableTest(TestCase):


### PR DESCRIPTION
- Modify the render_is_shared method to properly return whether the consortium has access (including auth domain membership and sharing).
- Rename the `WorkspaceSharedWithConsortiumTable` to `WorkspaceConsortiumAccessTable`.
- Rename the `is_shared` column to `consortium_access`.

Closes #278 