### PR TITLE
Add a "Share with auth domain" button to workspace detail pages

### DIFF
--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -961,6 +961,11 @@ class UploadWorkspaceDetailTest(TestCase):
                 codename=acm_models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
             )
         )
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename=acm_models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            )
+        )
         self.object = factories.UploadWorkspaceFactory.create()
 
     def get_url(self, *args):
@@ -976,6 +981,26 @@ class UploadWorkspaceDetailTest(TestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_contains_share_with_auth_domain_button(self):
+        acm_factories.WorkspaceAuthorizationDomainFactory.create(
+            workspace=self.object.workspace, group__name="test_auth"
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(
+                self.object.workspace.billing_project.name, self.object.workspace.name
+            )
+        )
+        url = reverse(
+            "anvil_consortium_manager:workspaces:sharing:new_by_group",
+            args=[
+                self.object.workspace.billing_project.name,
+                self.object.workspace.name,
+                "test_auth",
+            ],
+        )
+        self.assertContains(response, url)
 
 
 class UploadWorkspaceListTest(TestCase):
@@ -1472,6 +1497,11 @@ class ConsortiumCombinedDataWorkspaceDetailTest(TestCase):
                 codename=acm_models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
             )
         )
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename=acm_models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            )
+        )
         self.object = factories.CombinedConsortiumDataWorkspaceFactory.create()
 
     def get_url(self, *args):
@@ -1539,6 +1569,26 @@ class ConsortiumCombinedDataWorkspaceDetailTest(TestCase):
         self.assertIn(
             upload_workspace_2, response.context_data["upload_workspace_table"].data
         )
+
+    def test_contains_share_with_auth_domain_button(self):
+        acm_factories.WorkspaceAuthorizationDomainFactory.create(
+            workspace=self.object.workspace, group__name="test_auth"
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(
+                self.object.workspace.billing_project.name, self.object.workspace.name
+            )
+        )
+        url = reverse(
+            "anvil_consortium_manager:workspaces:sharing:new_by_group",
+            args=[
+                self.object.workspace.billing_project.name,
+                self.object.workspace.name,
+                "test_auth",
+            ],
+        )
+        self.assertContains(response, url)
 
 
 class ReleaseWorkspaceDetailTest(TestCase):

--- a/gregor_django/templates/gregor_anvil/combinedconsortiumdataworkspace_detail.html
+++ b/gregor_django/templates/gregor_anvil/combinedconsortiumdataworkspace_detail.html
@@ -6,3 +6,19 @@
     <dt class="col-sm-2">Upload cycle</dt> <dd class="col-sm-10"><a href="{{ object.combinedconsortiumdataworkspace.upload_cycle.get_absolute_url }}">{{ object.combinedconsortiumdataworkspace.upload_cycle }}</a></dd>
   </dl>
 {% endblock workspace_data %}
+
+
+{% block action_buttons %}
+
+{% if show_edit_links %}
+  {% if object.authorization_domains.first %}
+  <p>
+  <a href="{% url 'anvil_consortium_manager:workspaces:sharing:new_by_group' billing_project_slug=object.billing_project.name workspace_slug=object.name group_slug=object.authorization_domains.first.name %}" class="btn btn-primary" role="button">Share with auth domain</a>
+</p>
+  {% else %}
+  <p>no auth domain</p>
+  {% endif %}
+{% endif %}
+
+{{ block.super }}
+{% endblock action_buttons %}

--- a/gregor_django/templates/gregor_anvil/uploadworkspace_detail.html
+++ b/gregor_django/templates/gregor_anvil/uploadworkspace_detail.html
@@ -31,3 +31,17 @@
 
 {{ block.super }}
 {% endblock after_panel %}
+
+{% block action_buttons %}
+{% if show_edit_links %}
+  {% if object.authorization_domains.first %}
+  <p>
+  <a href="{% url 'anvil_consortium_manager:workspaces:sharing:new_by_group' billing_project_slug=object.billing_project.name workspace_slug=object.name group_slug=object.authorization_domains.first.name %}" class="btn btn-primary" role="button">Share with auth domain</a>
+</p>
+  {% else %}
+  <p>no auth domain</p>
+  {% endif %}
+{% endif %}
+
+{{ block.super }}
+{% endblock action_buttons %}


### PR DESCRIPTION
The ConsortiumCombinedDataWorkspace and UploadWorkspace detail pages now include a button that says "Share with auth domain?" with a link to the page that creates the new WorkspaceGroupSharing appropriately.