### PR TITLE
Use a sphinx version that supports Python 3.8

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -14,7 +14,8 @@ responses==0.21.0  # https://github.com/getsentry/responses - for mocking HTTP r
 
 # Documentation
 # ------------------------------------------------------------------------------
-sphinx==7.2.6  # https://github.com/sphinx-doc/sphinx
+# 7.2 drops support for Python 3.8
+sphinx==7.1.0  # https://github.com/sphinx-doc/sphinx
 sphinx-autobuild==2021.3.14 # https://github.com/GaretJax/sphinx-autobuild
 
 # Code quality


### PR DESCRIPTION
Accidentally merged a PR that broke CI, since we're running python 3.8.