### PR TITLE
Fix specification of ACM in requirements.in file

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -27,7 +27,7 @@ django-extensions  # https://github.com/django-extensions/django-extensions
 # Bootstrap5 templates for crispy-forms
 crispy-bootstrap5  # https://github.com/django-crispy-forms/crispy-bootstrap5
 
-git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.20.1
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.20.1
 
 # Simple history - model history tracking
 django-simple-history


### PR DESCRIPTION
Hopefully this will allow pip-compile/dependabot to include the ACM requirements as well. We are security alerts that dependabot can't install, I think because it thinks the django-anvil-consortium-manager repo is private?