### PR TITLE
Update certifi version to 2023.7.22

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -22,7 +22,7 @@ backcall==0.2.0
     # via ipython
 black==22.12.0
     # via -r requirements/dev-requirements.in
-certifi==2021.10.8
+certifi==2023.7.22
     # via
     #   -c requirements/requirements.txt
     #   -c requirements/test-requirements.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -39,3 +39,6 @@ mysqlclient # https://github.com/PyMySQL/mysqlclient
 # Required for django < 4.2 and django-simple-history is updated.
 # See issue https://github.com/jazzband/django-simple-history/issues/1255
 asgiref>=3.6
+
+# Temporary fixes to handle dependabot not reading django-anvil-consortium-manager dependencies
+certifi>=2023.7.22

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,8 +18,10 @@ build==1.0.3
     # via pip-tools
 cachetools==5.2.0
     # via google-auth
-certifi==2021.10.8
-    # via requests
+certifi==2023.7.22
+    # via
+    #   -r requirements/requirements.in
+    #   requests
 cffi==1.15.0
     # via
     #   argon2-cffi-bindings

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements/test-requirements.in
 #
-certifi==2021.10.8
+certifi==2023.7.22
     # via
     #   -c requirements/requirements.txt
     #   requests


### PR DESCRIPTION
The automatic security update failed because dependabot couldn't update dependencies that are only dependencies of ACM. Not entirely sure why, so fixing manually for now.