### PR TITLE
Allow both direct and indirect dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
     # Check for updates to GitHub Actions every weekday
     schedule:
       interval: "daily"
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"


### PR DESCRIPTION
By default all dependencies that are explicitly defined in a manifest are kept up to date by Dependabot version updates. We got a security update that reported:
"This is an indirect dependency not explicitly present in any manifest file, so Dependabot cannot update it."
so try adding dependency-type to the dependabot config.