### PR TITLE
Pin minimum version of pyjwt to fix security alert

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -42,3 +42,4 @@ asgiref>=3.6
 
 # Temporary fixes to handle dependabot not reading django-anvil-consortium-manager dependencies
 certifi>=2023.7.22
+pyjwt>=2.4.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -124,10 +124,10 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.8.0
     # via
+    #   -r requirements/requirements.in
     #   django-allauth
-    #   pyjwt
 pyparsing==3.0.8
     # via packaging
 pyproject-hooks==1.0.0


### PR DESCRIPTION
The security alert couldn't automatically resolve this for the following reason:
> Dependabot can't find the vulnerable dependency in the repository.
> This is an indirect dependency not explicitly present in any manifest file, so Dependabot cannot update it.