### PR TITLE
Pin django-environ to working version

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -14,6 +14,9 @@ oauthlib  # https://github.com/oauthlib/oauthlib
 # Django
 # ------------------------------------------------------------------------------
 django>=3.2,<4.0  # pyup: < 3.3  # https://www.djangoproject.com/
+# Note that django-environ introduces a bug where secret keys are truncated if they have a #
+# for now just update the requirements file manually, instead of pinning here.
+# https://github.com/joke2k/django-environ/issues/497
 django-environ  # https://github.com/joke2k/django-environ
 django-maintenance-mode # https://github.com/fabiocaccamo/django-maintenance-mode
 django-model-utils  # https://github.com/jazzband/django-model-utils

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -64,7 +64,7 @@ django-crispy-forms==2.0
     #   django-anvil-consortium-manager
 django-dbbackup==4.0.1
     # via -r requirements/requirements.in
-django-environ==0.11.2
+django-environ==0.10.0
     # via -r requirements/requirements.in
 django-extensions==3.2.1
     # via


### PR DESCRIPTION
django-environ>=0.11 introduces a bug where secret keys in a file that have a hash character in them are truncated. Downgrade to django-environ 0.10.0 to fix this for now.

See https://github.com/joke2k/django-environ/issues/497