### PR TITLE
Remove MariaDB 10.3 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # ahead of planned upgrades we can add versions as
         # needed
         python-version: [3.8]
-        mariadb-version: ["10.3", "10.4"]
+        mariadb-version: ["10.4"]
 
     services:
       mysql:


### PR DESCRIPTION
Since we're not running MariaDB 10.3 anymore, we don't need to test agianst it.