### PR TITLE
Handle factoryboy postgeneration updates

### DIFF
--- a/gregor_django/users/tests/factories.py
+++ b/gregor_django/users/tests/factories.py
@@ -34,7 +34,9 @@ class UserFactory(DjangoModelFactory):
             ).evaluate(None, None, extra={"locale": None})
         )
         self.set_password(password)
+        self.save()
 
     class Meta:
         model = get_user_model()
         django_get_or_create = ["username"]
+        skip_postgeneration_save = True


### PR DESCRIPTION
factoryboy is deprecating save after post-generation in v3.3.0. Handle the new warnings following their advice:
https://factoryboy.readthedocs.io/en/stable/changelog.html#id1