### PR TITLE
Django 4.2

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -20,6 +20,10 @@ babel==2.13.1
     # via sphinx
 backcall==0.2.0
     # via ipython
+backports-zoneinfo==0.2.1
+    # via
+    #   -c requirements/requirements.txt
+    #   django
 black==22.12.0
     # via -r requirements/dev-requirements.in
 certifi==2023.7.22
@@ -49,7 +53,7 @@ dill==0.3.7
     # via pylint
 distlib==0.3.7
     # via virtualenv
-django==3.2.23
+django==4.2.7
     # via
     #   -c requirements/requirements.txt
     #   django-debug-toolbar
@@ -173,7 +177,6 @@ pytz==2023.3.post1
     # via
     #   -c requirements/requirements.txt
     #   babel
-    #   django
 pyyaml==6.0.1
     # via
     #   -c requirements/test-requirements.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -13,7 +13,7 @@ oauthlib  # https://github.com/oauthlib/oauthlib
 
 # Django
 # ------------------------------------------------------------------------------
-django>=3.2,<4.0  # pyup: < 3.3  # https://www.djangoproject.com/
+django>=4.2,<5.0  # pyup: < 3.3  # https://www.djangoproject.com/
 # Note that django-environ introduces a bug where secret keys are truncated if they have a #
 # for now just update the requirements file manually, instead of pinning here.
 # https://github.com/joke2k/django-environ/issues/497

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,6 +14,8 @@ asgiref==3.7.2
     #   django
 async-timeout==4.0.2
     # via redis
+backports-zoneinfo==0.2.1
+    # via django
 build==1.0.3
     # via pip-tools
 cachetools==5.2.0
@@ -38,7 +40,7 @@ cryptography==41.0.4
     # via pyjwt
 defusedxml==0.7.1
     # via python3-openid
-django==3.2.23
+django==4.2.7
     # via
     #   -r requirements/requirements.in
     #   crispy-bootstrap5
@@ -141,7 +143,6 @@ python3-openid==3.2.0
 pytz==2023.3.post1
     # via
     #   -r requirements/requirements.in
-    #   django
     #   django-anvil-consortium-manager
     #   django-dbbackup
 redis==4.5.4


### PR DESCRIPTION
Update requirements.in to pin to any version of 4.2, and then recompile all the requriements files.