### PR TITLE
Add argon2-cffi back to requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -6,6 +6,9 @@ whitenoise  # https://github.com/evansd/whitenoise
 # Login via oauth
 oauthlib  # https://github.com/oauthlib/oauthlib
 
+# Password hashing
+argon2-cffi # https://github.com/hynek/argon2_cffi
+
 django>=4.2,<5.0  # pyup: < 3.3  # https://www.djangoproject.com/
 # Read from .env files
 # Note that django-environ 0.11+ introduces a bug where secret keys are truncated if they have a #

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements/requirements.in
 #
+argon2-cffi==23.1.0
+    # via -r requirements/requirements.in
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
 asgiref==3.7.2
     # via
     #   -r requirements/requirements.in
@@ -19,7 +23,9 @@ certifi==2023.7.22
     #   -r requirements/requirements.in
     #   requests
 cffi==1.16.0
-    # via cryptography
+    # via
+    #   argon2-cffi-bindings
+    #   cryptography
 charset-normalizer==2.0.12
     # via requests
 click==8.1.7


### PR DESCRIPTION
Removing it broke logins to the admin interface.