### PR TITLE
Update to latest version of django-maintenance-mode

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -15,7 +15,8 @@ django>=4.2,<5.0  # pyup: < 3.3  # https://www.djangoproject.com/
 # https://github.com/joke2k/django-environ/issues/497
 django-environ<0.11.0  # https://github.com/joke2k/django-environ
 # Turn on and off maintenance mode
-django-maintenance-mode # https://github.com/fabiocaccamo/django-maintenance-mode
+# 0.21.1 fixes a bug with permissions of the maintenance mode file.
+django-maintenance-mode>=0.21.1 # https://github.com/fabiocaccamo/django-maintenance-mode
 # Model utilities
 django-model-utils  # https://github.com/jazzband/django-model-utils
 # login/auth via Drupal or other Social Application

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -73,7 +73,7 @@ django-filter==23.5
     # via django-anvil-consortium-manager
 django-login-required-middleware==0.9.0
     # via -r requirements/requirements.in
-django-maintenance-mode==0.21.0
+django-maintenance-mode==0.21.1
     # via -r requirements/requirements.in
 django-model-utils==4.3.1
     # via -r requirements/requirements.in
@@ -125,7 +125,7 @@ pyjwt[crypto]==2.8.0
     #   django-allauth
 pyproject-hooks==1.0.0
     # via build
-python-fsutil==0.13.0
+python-fsutil==0.13.1
     # via django-maintenance-mode
 python3-openid==3.2.0
     # via django-allauth


### PR DESCRIPTION
This update fixes a bug where the permissions of the maintenance mode state file are not properly maintained (due to the implementation in python-fsutil). v0.21.1 of django maintenance mode requires the version of python-fsutil where this bug is fixed. See fabiocaccamo/django-maintenance-mode#172 for info.