### PR TITLE
Convert pytest warnings to errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
           pip install pip-tools
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
 
+      - name: Collect staticfiles
+        run: python manage.py collectstatic --noinput --settings=config.settings.test
+
       - name: Run tests
         run:  coverage run -p -m pytest
         env:
@@ -124,6 +127,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install pip-tools
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
+
+      - name: Collect staticfiles
+        run: python manage.py collectstatic --noinput --settings=config.settings.test
 
       - name: Run tests
         run:  coverage run -p -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,12 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
 
+
     env:
       # mysql://user:password@host:port/database
       DATABASE_URL: "mysql://root:root@127.0.0.1:3306/mysql"
+      # We can set this to an empty string, since we'll never make an API call.
+      ANVIL_API_SERVICE_ACCOUNT_FILE: foo
 
     steps:
 
@@ -98,6 +101,10 @@ jobs:
 
   pytest-sqlite:
     runs-on: ubuntu-latest
+
+    env:
+      # We can set this to an empty string, since we'll never make an API call.
+      ANVIL_API_SERVICE_ACCOUNT_FILE: foo
 
     steps:
       - name: Checkout Code Repository

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 addopts = --ds=config.settings.test --reuse-db
 python_files = tests.py test_*.py
+filterwarnings =
+    # Convert all warnings to errors.
+    error

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -162,7 +162,7 @@ pylint-django==2.5.5
     # via -r requirements/dev-requirements.in
 pylint-plugin-utils==0.8.2
     # via pylint-django
-pytz==2023.3.post1
+pytz==2023.4
     # via
     #   -c requirements/requirements.txt
     #   babel


### PR DESCRIPTION
Convert all warnings to errors when running pytest. This should help catch DeprecationErrors that are raised in dependabot updates.