### PR TITLE
Add ability to show site-wide banner announcements

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -84,6 +84,7 @@ THIRD_PARTY_APPS = [
     "dal_select2",
     "fontawesomefree",
     "simple_history",
+    "constance",
 ]
 
 LOCAL_APPS = [
@@ -198,6 +199,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
+                "constance.context_processors.config",
                 "gregor_django.utils.context_processors.settings_context",
             ],
         },
@@ -361,6 +363,17 @@ DCC_CONTACT_EMAIL = "gregorconsortium@uw.edu"
 # ------------------------------------------------------------------------------
 # https://django-tables2.readthedocs.io/en/latest/pages/custom-rendering.html?highlight=django_tables2_template#available-templates
 DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
+
+# django-constance
+# ------------------------------------------------------------------------------
+CONSTANCE_CONFIG = {
+    "ANNOUNCEMENT_TEXT": ("", "Site-wide announcement message", str),
+}
+
+CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
+CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
+# CONSTANCE_DATABASE_CACHE_BACKEND = "default"
+CONSTANCE_DATABASE_CACHE_AUTOFILL_TIMEOUT = None
 
 # django-anvil-consortium-manager
 # ------------------------------------------------------------------------------

--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -7,6 +7,7 @@ from anvil_consortium_manager import models as acm_models
 from anvil_consortium_manager.models import AnVILProjectManagerAccess
 from anvil_consortium_manager.tests import factories as acm_factories
 from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
+from constance.test import override_config
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -95,6 +96,26 @@ class HomeTest(TestCase):
         self.assertNotIn(
             reverse("anvil_consortium_manager:index"), response.rendered_content
         )
+
+    def test_site_announcement_no_text(self):
+        user = User.objects.create_user(username="test-none", password="test-none")
+        self.client.force_login(user)
+        response = self.client.get(self.get_url())
+        self.assertNotContains(response, """id="alert-announcement""")
+
+    @override_config(ANNOUNCEMENT_TEXT="This is a test announcement")
+    def test_site_announcement_text(self):
+        user = User.objects.create_user(username="test-none", password="test-none")
+        self.client.force_login(user)
+        response = self.client.get(self.get_url())
+        self.assertContains(response, """id="alert-announcement""")
+        self.assertContains(response, "This is a test announcement")
+
+    @override_config(ANNOUNCEMENT_TEXT="This is a test announcement")
+    def test_site_announcement_text_unauthenticated_user(self):
+        response = self.client.get(self.get_url(), follow=True)
+        self.assertContains(response, """id="alert-announcement""")
+        self.assertContains(response, "This is a test announcement")
 
 
 class ConsentGroupDetailTest(TestCase):

--- a/gregor_django/templates/base.html
+++ b/gregor_django/templates/base.html
@@ -104,16 +104,25 @@
       </div>
     </nav>
 
-    {% block extra_navbar %}
-    {% endblock %}
     <main class="flex-shrink-0">
     <div class="container">
+
+      {% if config.ANNOUNCEMENT_TEXT %}
+        <div class="alert alert-info my-3" role="alert" id="alert-announcement">
+          <i class="bi bi-megaphone-fill me-1"></i>
+          {{ config.ANNOUNCEMENT_TEXT }}
+        </div>
+      {% endif %}
 
       {% if messages %}
           {% for message in messages %}
               <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} alert-dismissible fade show" role="alert">{{ message }}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>
           {% endfor %}
       {% endif %}
+
+      {% block extra_navbar %}
+      {% endblock %}
+
 
       {% block content %}
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,3 +51,7 @@ certifi>=2023.7.22
 pyjwt>=2.4.0
 urllib3>=1.26.18
 sqlparse>=0.4.4
+
+# Dynamic settings
+django-constance
+django-picklefield  # Required by django-constance for database backend

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -51,6 +51,7 @@ django==4.2.11
     #   django-extensions
     #   django-filter
     #   django-model-utils
+    #   django-picklefield
     #   django-tables2
 django-allauth==0.54.0
     # via -r requirements/requirements.in
@@ -58,6 +59,8 @@ django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-con
     # via -r requirements/requirements.in
 django-autocomplete-light==3.11.0
     # via django-anvil-consortium-manager
+django-constance==3.1.0
+    # via -r requirements/requirements.in
 django-crispy-forms==2.1
     # via
     #   -r requirements/requirements.in
@@ -79,6 +82,10 @@ django-maintenance-mode==0.21.1
     # via -r requirements/requirements.in
 django-model-utils==4.4.0
     # via -r requirements/requirements.in
+django-picklefield==3.1
+    # via
+    #   -r requirements/requirements.in
+    #   django-constance
 django-simple-history==3.5.0
     # via
     #   -r requirements/requirements.in


### PR DESCRIPTION
- Use the django-constance app to add settings that can be edited in the admin
- Add a SITE_ANNOUNCEMENT setting
- If SITE_ANNOUNCEMENT is non-blank, show an alert with the text of the site announcement