### PR TITLE
Pin django stubs to a version matching django 4.2

### DIFF
--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -7,7 +7,7 @@ ipdb  # https://github.com/gotcha/ipdb
 # Testing
 # ------------------------------------------------------------------------------
 mypy  # https://github.com/python/mypy
-django-stubs  # https://github.com/typeddjango/django-stubs
+django-stubs>=4.2,<5.0  # https://github.com/typeddjango/django-stubs
 
 # Documentation
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
dependabot tried to update this to v5.0 but we are using Django 4.2.