### PR TITLE
Add optional step to recompile pip tools in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         mariadb-version: ["10.4"]
         include:
           # Note that we can't use python 3.12 until we figure out how to have separate requirements files.
-          - python-version: 3.12  # Possible future version.
+          - python-version: 3.8  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
-          - python-version: 3.12  # Possible future version.
+          - python-version: 3.8  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
             pip-recompile: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Recompile pip files if requested
         if: matrix.pip-recompile
         run: |
+          python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           pip install pip-tools
           pip-compile requirements/requirements.in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         mariadb-version: ["10.4"]
         include:
           # Note that we can't use python 3.12 until we figure out how to have separate requirements files.
-          - python-version: 3.8  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
@@ -75,7 +75,7 @@ jobs:
           python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           # Upgrade setup tools
-          pip install --upgrade setuptools
+          python -m pip install --upgrade setuptools
 
       - name: Install piptools
         run: pip install pip-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
         run: |
           pip-compile requirements/requirements.in
           pip-compile requirements/test-requirements.in
+          # Print out changes.
+          git diff
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           python -m pip install --upgrade setuptools
 
       - name: Install piptools
-        run: pip install pip-tools
+        run: python -m pip install pip-tools
 
       - name: Recompile pip files if requested
         if: matrix.pip-recompile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
-          - python-version: 3.8  # Possible future version.
+          - python-version: 3.11  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
             pip-recompile: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         mariadb-version: ["10.4"]
         include:
           # Note that we can't use python 3.12 until we figure out how to have separate requirements files.
-          - python-version: 3.12  # Possible future version.
+          - python-version: 3.11  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,19 +70,22 @@ jobs:
             requirements/requirements.txt
             requirements/test-requirements.txt
 
+      - name: Ensure pip is installed
+        run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
+
+      - name: Install piptools
+        run: pip install pip-tools
+
       - name: Recompile pip files if requested
         if: matrix.pip-recompile
         run: |
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade setuptools
-          pip install pip-tools
           pip-compile requirements/requirements.in
           pip-compile requirements/test-requirements.in
 
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pip-tools
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
 
       - name: Collect staticfiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,11 @@ jobs:
           - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
+            pip-recompile: true
           - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
+            pip-recompile: true
 
     name: "py${{ matrix.python-version }}-${{ matrix.backend }}-${{ matrix.mariadb-version }}"
 
@@ -67,6 +69,14 @@ jobs:
           cache-dependency-path: |
             requirements/requirements.txt
             requirements/test-requirements.txt
+
+      - name: Recompile pip files if requested
+        if: matrix.pip-recompile
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-tools
+          pip-compile requirements/requirements.in
+          pip-compile requirements/test-requirements.in
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         if: matrix.pip-recompile
         run: |
           python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
           pip install pip-tools
           pip-compile requirements/requirements.in
           pip-compile requirements/test-requirements.in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
         mariadb-version: ["10.4"]
         include:
           # Note that we can't use python 3.12 until we figure out how to have separate requirements files.
-          - python-version: 3.8  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
-          - python-version: 3.8  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
         run: |
           python -m ensurepip --upgrade
           python -m pip install --upgrade pip
+          # Upgrade setup tools
+          pip install --upgrade setuptools
 
       - name: Install piptools
         run: pip install pip-tools


### PR DESCRIPTION
- Add a step to the CI that (optionally) reruns pip-compile on the requirements.in files
- Add a `pip-recompile` setting to the matrix definitions that can be used to toggle whether this step should run.

The pip-recompile setting can be set to true when we want to test future versions of python compared to what is running on the live servers.