### PR TITLE
Run python3.12 in additional CI strategies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,11 @@ jobs:
         backend: ["sqlite", "mariadb"]
         mariadb-version: ["10.4"]
         include:
-          # Note that we can't use python 3.12 until we figure out how to have separate requirements files.
-          - python-version: 3.11  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
-          - python-version: 3.11  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
             pip-recompile: true

--- a/gregor_django/drupal_oauth_provider/tests.py
+++ b/gregor_django/drupal_oauth_provider/tests.py
@@ -107,7 +107,7 @@ class CustomProviderTests(OAuth2TestsMixin, TestCase):
     # This login response mimics drupals in that it contains a set of scopes
     # and the uid which has the name sub
     def get_login_response_json(self, with_refresh_token=True):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         app = get_adapter().get_app(request=None, provider=self.provider_id)
         allowed_audience = app.client_id
         id_token = sign_id_token(

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ python_files = tests.py test_*.py
 filterwarnings =
     # Convert all warnings to errors.
     error
+    ignore:'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14:DeprecationWarning

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,7 @@ django-extensions  # https://github.com/django-extensions/django-extensions
 # Bootstrap5 templates for crispy-forms
 crispy-bootstrap5  # https://github.com/django-crispy-forms/crispy-bootstrap5
 
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22.1
 
 # Simple history - model history tracking
 django-simple-history

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -55,7 +55,7 @@ django==4.2.11
     #   django-tables2
 django-allauth==0.54.0
     # via -r requirements/requirements.in
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22.1
     # via -r requirements/requirements.in
 django-autocomplete-light==3.11.0
     # via django-anvil-consortium-manager


### PR DESCRIPTION
- Run python3.12 in additional CI strategies
- Upgrade to ACM v0.22.1, which fixes an issue with numpy/setuptools in python3.12
- Fix various DeprecationWarnings from third party packages