### PR TITLE
Fix issue with account link on profile page

### DIFF
--- a/gregor_django/templates/users/user_detail.html
+++ b/gregor_django/templates/users/user_detail.html
@@ -76,7 +76,7 @@
               </li>
               {% endif %}
             </ul>
-          {% elif object.useremailentry_set.all %}
+          {% elif user_email_entries %}
             <ul>
             {% for uee in user_email_entries %}
               <li><i class="bi bi-hourglass-split"></i> AnVIL account user email verification in progress for email: {{ uee.email }}


### PR DESCRIPTION
The page should have been using the context user_email_entries object instead of accessing it from the user, because the context object filters out verified emails that are no longer linked. This caused the warning about no linked account to be hidden.