### PR TITLE
Fix member and upload tables when groups are not set

### DIFF
--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -333,6 +333,14 @@ class ResearchCenterDetailTest(TestCase):
         self.assertIn(account, table.data)
         self.assertNotIn(other_account, table.data)
 
+    def test_member_table_group_not_set(self):
+        obj = self.model_factory.create()
+        acm_factories.AccountFactory.create(verified=True)
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(obj.pk))
+        table = response.context_data["tables"][1]
+        self.assertEqual(len(table.rows), 0)
+
     def test_rc_uploader_table(self):
         uploader_group = acm_factories.ManagedGroupFactory.create()
         obj = self.model_factory.create(uploader_group=uploader_group)
@@ -345,6 +353,14 @@ class ResearchCenterDetailTest(TestCase):
         self.assertEqual(len(table.rows), 1)
         self.assertIn(account, table.data)
         self.assertNotIn(other_account, table.data)
+
+    def test_upload_table_group_not_set(self):
+        obj = self.model_factory.create()
+        acm_factories.AccountFactory.create(verified=True)
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(obj.pk))
+        table = response.context_data["tables"][2]
+        self.assertEqual(len(table.rows), 0)
 
 
 class ResearchCenterListTest(TestCase):
@@ -512,6 +528,14 @@ class PartnerGroupDetailTest(TestCase):
         self.assertIn(account, table.data)
         self.assertNotIn(other_account, table.data)
 
+    def test_member_table_group_not_set(self):
+        obj = self.model_factory.create()
+        acm_factories.AccountFactory.create(verified=True)
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(obj.pk))
+        table = response.context_data["tables"][1]
+        self.assertEqual(len(table.rows), 0)
+
     def test_uploader_table(self):
         uploader_group = acm_factories.ManagedGroupFactory.create()
         obj = self.model_factory.create(uploader_group=uploader_group)
@@ -524,6 +548,14 @@ class PartnerGroupDetailTest(TestCase):
         self.assertEqual(len(table.rows), 1)
         self.assertIn(account, table.data)
         self.assertNotIn(other_account, table.data)
+
+    def test_upload_table_group_not_set(self):
+        obj = self.model_factory.create()
+        acm_factories.AccountFactory.create(verified=True)
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(obj.pk))
+        table = response.context_data["tables"][2]
+        self.assertEqual(len(table.rows), 0)
 
 
 class PartnerGroupListTest(TestCase):

--- a/gregor_django/gregor_anvil/views.py
+++ b/gregor_django/gregor_anvil/views.py
@@ -35,12 +35,18 @@ class ResearchCenterDetail(AnVILConsortiumManagerStaffViewRequired, MultiTableMi
     model = models.ResearchCenter
 
     def get_tables(self):
-        members = Account.objects.filter(
-            groupaccountmembership__group=self.object.member_group,
-        )
-        uploaders = Account.objects.filter(
-            groupaccountmembership__group=self.object.uploader_group,
-        )
+        if self.object.member_group is None:
+            members = Account.objects.none()
+        else:
+            members = Account.objects.filter(
+                groupaccountmembership__group=self.object.member_group,
+            )
+        if self.object.uploader_group is None:
+            uploaders = Account.objects.none()
+        else:
+            uploaders = Account.objects.filter(
+                groupaccountmembership__group=self.object.uploader_group,
+            )
         return [
             UserTable(User.objects.filter(research_centers=self.object)),
             tables.AccountTable(members, exclude=("user__research_centers", "number_groups")),
@@ -61,12 +67,18 @@ class PartnerGroupDetail(AnVILConsortiumManagerStaffViewRequired, MultiTableMixi
     model = models.PartnerGroup
 
     def get_tables(self):
-        members = Account.objects.filter(
-            groupaccountmembership__group=self.object.member_group,
-        )
-        uploaders = Account.objects.filter(
-            groupaccountmembership__group=self.object.uploader_group,
-        )
+        if self.object.member_group is None:
+            members = Account.objects.none()
+        else:
+            members = Account.objects.filter(
+                groupaccountmembership__group=self.object.member_group,
+            )
+        if self.object.uploader_group is None:
+            uploaders = Account.objects.none()
+        else:
+            uploaders = Account.objects.filter(
+                groupaccountmembership__group=self.object.uploader_group,
+            )
         return [
             UserTable(User.objects.filter(partner_groups=self.object)),
             tables.AccountTable(members, exclude=("user__research_centers", "number_groups")),


### PR DESCRIPTION
The tables of members with data access and uploaders were incorrect when the groups were not set - instead, it showed all accounts. Fix this in the view and add tests to catch this case.