### PR TITLE
Hide inactive users in ResearchCenter and PartnerGroup detail views

### DIFF
--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -290,6 +290,19 @@ class ResearchCenterDetailTest(TestCase):
         self.assertIn(site_user, table.data)
         self.assertNotIn(non_site_user, table.data)
 
+    def test_site_user_table_does_not_include_inactive_users(self):
+        """Site user table does not include inactive users."""
+        obj = self.model_factory.create()
+        inactive_site_user = UserFactory.create()
+        inactive_site_user.research_centers.set([obj])
+        inactive_site_user.is_active = False
+        inactive_site_user.save()
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(obj.pk))
+        table = response.context_data["tables"][0]
+        self.assertEqual(len(table.rows), 0)
+        self.assertNotIn(inactive_site_user, table.data)
+
     def test_link_to_member_group(self):
         """Response includes a link to the members group if it exists."""
         member_group = acm_factories.ManagedGroupFactory.create()
@@ -503,6 +516,19 @@ class PartnerGroupDetailTest(TestCase):
 
         self.assertIn(pg_user, table.data)
         self.assertNotIn(non_pg_user, table.data)
+
+    def test_site_user_table_does_not_include_inactive_users(self):
+        """Site user table does not include inactive users."""
+        obj = self.model_factory.create()
+        inactive_site_user = UserFactory.create()
+        inactive_site_user.partner_groups.set([obj])
+        inactive_site_user.is_active = False
+        inactive_site_user.save()
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(obj.pk))
+        table = response.context_data["tables"][0]
+        self.assertEqual(len(table.rows), 0)
+        self.assertNotIn(inactive_site_user, table.data)
 
     def test_table_classes(self):
         """Table classes are correct."""

--- a/gregor_django/gregor_anvil/views.py
+++ b/gregor_django/gregor_anvil/views.py
@@ -48,7 +48,7 @@ class ResearchCenterDetail(AnVILConsortiumManagerStaffViewRequired, MultiTableMi
                 groupaccountmembership__group=self.object.uploader_group,
             )
         return [
-            UserTable(User.objects.filter(research_centers=self.object)),
+            UserTable(User.objects.filter(is_active=True, research_centers=self.object)),
             tables.AccountTable(members, exclude=("user__research_centers", "number_groups")),
             tables.AccountTable(uploaders, exclude=("user__research_centers", "number_groups")),
         ]
@@ -80,7 +80,7 @@ class PartnerGroupDetail(AnVILConsortiumManagerStaffViewRequired, MultiTableMixi
                 groupaccountmembership__group=self.object.uploader_group,
             )
         return [
-            UserTable(User.objects.filter(partner_groups=self.object)),
+            UserTable(User.objects.filter(is_active=True, partner_groups=self.object)),
             tables.AccountTable(members, exclude=("user__research_centers", "number_groups")),
             tables.AccountTable(uploaders, exclude=("user__research_centers", "number_groups")),
         ]


### PR DESCRIPTION
The site user table showed inactive users associated with the ResearchCenter or PartnerGroup. Filter them out in the table queryset so the table only shows active users.