### PR TITLE
Add permissions for pip-compile workflow

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  pull-requests: write
+  contents: write
 
 jobs:
   update-requirements-files:


### PR DESCRIPTION
This should(?) allow the create-pull-request action to run and create a PR on dependabot updates. (This mostly affects security updates?)