### PR TITLE
Automate adding DCC admins group to workspaces and managed groups

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -383,6 +383,7 @@ ANVIL_WORKSPACE_ADAPTERS = [
     "gregor_django.gregor_anvil.adapters.ExchangeWorkspaceAdapter",
 ]
 ANVIL_ACCOUNT_ADAPTER = "gregor_django.gregor_anvil.adapters.AccountAdapter"
+ANVIL_MANAGED_GROUP_ADAPTER = "gregor_django.gregor_anvil.adapters.ManagedGroupAdapter"
 
 # Specify the URL name that AccountLink and AccountLinkVerify redirect to.
 ANVIL_ACCOUNT_LINK_REDIRECT = "users:redirect"

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -65,3 +65,4 @@ LOGIN_REQUIRED_IGNORE_VIEW_NAMES += [  # noqa F405
 # ------------------------------------------------------------------------------
 # Specify the path to the service account to use for managing access on AnVIL.
 ANVIL_API_SERVICE_ACCOUNT_FILE = env("ANVIL_API_SERVICE_ACCOUNT_FILE")
+ANVIL_DCC_ADMINS_GROUP_NAME = env("ANVIL_DCC_ADMINS_GROUP_NAME", default="DEV_GREGOR_DCC_ADMINS")

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -156,3 +156,4 @@ LOGGING = {
 # ------------------------------------------------------------------------------
 # Specify the path to the service account to use for managing access on AnVIL.
 ANVIL_API_SERVICE_ACCOUNT_FILE = env("ANVIL_API_SERVICE_ACCOUNT_FILE")
+ANVIL_DCC_ADMINS_GROUP_NAME = "GREGOR_DCC_ADMINS"

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -35,3 +35,4 @@ ANVIL_API_SERVICE_ACCOUNT_FILE = "foo"
 # template tests require debug to be set
 # get the last templates entry and set debug option
 TEMPLATES[-1]["OPTIONS"]["debug"] = True  # noqa
+ANVIL_DCC_ADMINS_GROUP_NAME = "TEST_GREGOR_DCC_ADMINS"

--- a/gregor_django/gregor_anvil/adapters.py
+++ b/gregor_django/gregor_anvil/adapters.py
@@ -1,7 +1,13 @@
 from anvil_consortium_manager.adapters.account import BaseAccountAdapter
+from anvil_consortium_manager.adapters.managed_group import BaseManagedGroupAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
-from anvil_consortium_manager.models import ManagedGroup, WorkspaceGroupSharing
+from anvil_consortium_manager.models import (
+    GroupGroupMembership,
+    ManagedGroup,
+    WorkspaceGroupSharing,
+)
+from anvil_consortium_manager.tables import ManagedGroupStaffTable
 from django.conf import settings
 from django.db.models import Q
 
@@ -75,6 +81,26 @@ class AccountAdapter(BaseAccountAdapter):
         else:
             name = "---"
         return "{} ({})".format(name, account.email)
+
+
+class ManagedGroupAdapter(BaseManagedGroupAdapter):
+    """Adapter for ManagedGroups."""
+
+    list_table_class = ManagedGroupStaffTable
+
+    def after_anvil_create(self, managed_group):
+        super().after_anvil_create(managed_group)
+        # Add the ADMINs group as an admin of the auth domain.
+        try:
+            admins_group = ManagedGroup.objects.get(name=settings.ANVIL_DCC_ADMINS_GROUP_NAME)
+        except ManagedGroup.DoesNotExist:
+            return
+        membership = GroupGroupMembership.objects.create(
+            parent_group=managed_group,
+            child_group=admins_group,
+            role=GroupGroupMembership.ADMIN,
+        )
+        membership.anvil_create()
 
 
 class UploadWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):

--- a/gregor_django/gregor_anvil/adapters.py
+++ b/gregor_django/gregor_anvil/adapters.py
@@ -26,6 +26,35 @@ class WorkspaceAdminSharingAdapterMixin:
         )
         sharing.anvil_create_or_update()
 
+    def after_anvil_import(self, workspace):
+        super().after_anvil_import(workspace)
+        # # Check if the workspace is already shared with the ADMINs group.
+        try:
+            admins_group = ManagedGroup.objects.get(name=settings.ANVIL_DCC_ADMINS_GROUP_NAME)
+        except ManagedGroup.DoesNotExist:
+            return
+        try:
+            sharing = WorkspaceGroupSharing.objects.get(
+                workspace=workspace,
+                group=admins_group,
+            )
+        except WorkspaceGroupSharing.DoesNotExist:
+            sharing = WorkspaceGroupSharing.objects.create(
+                workspace=workspace,
+                group=admins_group,
+                access=WorkspaceGroupSharing.OWNER,
+                can_compute=True,
+            )
+            sharing.save()
+            sharing.anvil_create_or_update()
+        else:
+            # If the existing sharing record exists, make sure it has the correct permissions.
+            if not sharing.can_compute or sharing.access != WorkspaceGroupSharing.OWNER:
+                sharing.can_compute = True
+                sharing.access = WorkspaceGroupSharing.OWNER
+                sharing.save()
+                sharing.anvil_create_or_update()
+
 
 class AccountAdapter(BaseAccountAdapter):
     """Custom account adapter for PRIMED."""

--- a/gregor_django/gregor_anvil/adapters.py
+++ b/gregor_django/gregor_anvil/adapters.py
@@ -77,7 +77,7 @@ class AccountAdapter(BaseAccountAdapter):
         return "{} ({})".format(name, account.email)
 
 
-class UploadWorkspaceAdapter(BaseWorkspaceAdapter):
+class UploadWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for UploadWorkspaces."""
 
     type = "upload"
@@ -106,7 +106,7 @@ class UploadWorkspaceAdapter(BaseWorkspaceAdapter):
         return queryset
 
 
-class PartnerUploadWorkspaceAdapter(BaseWorkspaceAdapter):
+class PartnerUploadWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for PartnerUploadWorkspaces."""
 
     type = "partner_upload"
@@ -121,7 +121,7 @@ class PartnerUploadWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_detail_template_name = "gregor_anvil/partneruploadworkspace_detail.html"
 
 
-class ResourceWorkspaceAdapter(BaseWorkspaceAdapter):
+class ResourceWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for ResourceWorkspaces."""
 
     type = "resource"
@@ -137,7 +137,7 @@ class ResourceWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = WorkspaceForm
 
 
-class TemplateWorkspaceAdapter(BaseWorkspaceAdapter):
+class TemplateWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for ExampleWorkspaces."""
 
     type = "template"
@@ -151,7 +151,7 @@ class TemplateWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = WorkspaceForm
 
 
-class CombinedConsortiumDataWorkspaceAdapter(BaseWorkspaceAdapter):
+class CombinedConsortiumDataWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for CombinedConsortiumDataWorkspace."""
 
     type = "combined_consortium"
@@ -165,7 +165,7 @@ class CombinedConsortiumDataWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = WorkspaceForm
 
 
-class ReleaseWorkspaceAdapter(BaseWorkspaceAdapter):
+class ReleaseWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for ReleaseWorkspace."""
 
     type = "release"
@@ -179,7 +179,7 @@ class ReleaseWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = WorkspaceForm
 
 
-class DCCProcessingWorkspaceAdapter(BaseWorkspaceAdapter):
+class DCCProcessingWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for DCCProcessingWorkspace."""
 
     type = "dcc_processing"
@@ -193,7 +193,7 @@ class DCCProcessingWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = WorkspaceForm
 
 
-class DCCProcessedDataWorkspaceAdapter(BaseWorkspaceAdapter):
+class DCCProcessedDataWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for DCCProcessedDataWorkspace."""
 
     type = "dcc_processed_data"
@@ -207,7 +207,7 @@ class DCCProcessedDataWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = WorkspaceForm
 
 
-class ExchangeWorkspaceAdapter(BaseWorkspaceAdapter):
+class ExchangeWorkspaceAdapter(WorkspaceAdminSharingAdapterMixin, BaseWorkspaceAdapter):
     """Adapter for ExchangeWorkspaces."""
 
     type = "exchange"

--- a/gregor_django/gregor_anvil/tests/test_adapters.py
+++ b/gregor_django/gregor_anvil/tests/test_adapters.py
@@ -1,9 +1,8 @@
 import responses
 from anvil_consortium_manager.adapters.default import DefaultWorkspaceAdapter
-from anvil_consortium_manager.models import Account, WorkspaceGroupSharing
+from anvil_consortium_manager.models import Account, GroupGroupMembership, WorkspaceGroupSharing
 from anvil_consortium_manager.tests.factories import (
     AccountFactory,
-    GroupGroupMembership,
     ManagedGroupFactory,
     WorkspaceFactory,
     WorkspaceGroupSharingFactory,
@@ -267,7 +266,7 @@ class ManagedGroupAdapterTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(membership.child_group, admins_group)
         self.assertEqual(membership.role, GroupGroupMembership.ADMIN)
 
-    @override_settings(ANVIL_CC_ADMINS_GROUP_NAME="foobar")
+    @override_settings(ANVIL_DCC_ADMINS_GROUP_NAME="foobar")
     def test_after_anvil_create_different_admins_group(self):
         admins_group = ManagedGroupFactory.create(name="foobar")
         managed_group = ManagedGroupFactory.create(name="test-group")

--- a/gregor_django/gregor_anvil/tests/test_adapters.py
+++ b/gregor_django/gregor_anvil/tests/test_adapters.py
@@ -1,6 +1,13 @@
-from anvil_consortium_manager.models import Account
-from anvil_consortium_manager.tests.factories import AccountFactory
-from django.test import TestCase
+import responses
+from anvil_consortium_manager.adapters.default import DefaultWorkspaceAdapter
+from anvil_consortium_manager.models import Account, WorkspaceGroupSharing
+from anvil_consortium_manager.tests.factories import (
+    AccountFactory,
+    ManagedGroupFactory,
+    WorkspaceFactory,
+)
+from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
+from django.test import TestCase, override_settings
 
 from gregor_django.users.tests.factories import UserFactory
 
@@ -57,3 +64,85 @@ class AccountAdapterTest(TestCase):
         self.assertEqual(len(queryset), 1)
         self.assertIn(account_1, queryset)
         self.assertNotIn(account_2, queryset)
+
+
+class WorkspaceAdminSharingAdapterMixin(AnVILAPIMockTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+
+        class TestAdapter(adapters.WorkspaceAdminSharingAdapterMixin, DefaultWorkspaceAdapter):
+            pass
+
+        self.adapter = TestAdapter()
+
+    def test_after_anvil_create(self):
+        admins_group = ManagedGroupFactory.create(name="TEST_GREGOR_DCC_ADMINS")
+        workspace = WorkspaceFactory.create(
+            billing_project__name="bar", name="foo", workspace_type=self.adapter.get_type()
+        )
+        # API response for admin group workspace owner.
+        acls = [
+            {
+                "email": "TEST_GREGOR_DCC_ADMINS@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point + "/api/workspaces/bar/foo/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_create(workspace)
+        # Check for WorkspaceGroupSharing.
+        self.assertEqual(WorkspaceGroupSharing.objects.count(), 1)
+        sharing = WorkspaceGroupSharing.objects.first()
+        self.assertEqual(sharing.workspace, workspace)
+        self.assertEqual(sharing.group, admins_group)
+        self.assertEqual(sharing.access, WorkspaceGroupSharing.OWNER)
+        self.assertTrue(sharing.can_compute)
+
+    @override_settings(ANVIL_DCC_ADMINS_GROUP_NAME="foobar")
+    def test_after_anvil_create_different_admins_group(self):
+        admins_group = ManagedGroupFactory.create(name="foobar")
+        workspace = WorkspaceFactory.create(
+            billing_project__name="bar", name="foo", workspace_type=self.adapter.get_type()
+        )
+        # API response for admin group workspace owner.
+        acls = [
+            {
+                "email": "foobar@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point + "/api/workspaces/bar/foo/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_create(workspace)
+        # Check for WorkspaceGroupSharing.
+        self.assertEqual(WorkspaceGroupSharing.objects.count(), 1)
+        sharing = WorkspaceGroupSharing.objects.first()
+        self.assertEqual(sharing.workspace, workspace)
+        self.assertEqual(sharing.group, admins_group)
+        self.assertEqual(sharing.access, WorkspaceGroupSharing.OWNER)
+        self.assertTrue(sharing.can_compute)
+
+    def test_after_anvil_create_no_admins_group(self):
+        workspace = WorkspaceFactory.create(
+            billing_project__name="bar", name="foo", workspace_type=self.adapter.get_type()
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_create(workspace)
+        # No WorkspaceGroupSharing objects were created.
+        self.assertEqual(WorkspaceGroupSharing.objects.count(), 0)

--- a/gregor_django/gregor_anvil/tests/test_adapters.py
+++ b/gregor_django/gregor_anvil/tests/test_adapters.py
@@ -5,6 +5,7 @@ from anvil_consortium_manager.tests.factories import (
     AccountFactory,
     ManagedGroupFactory,
     WorkspaceFactory,
+    WorkspaceGroupSharingFactory,
 )
 from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
 from django.test import TestCase, override_settings
@@ -146,3 +147,95 @@ class WorkspaceAdminSharingAdapterMixin(AnVILAPIMockTestMixin, TestCase):
         self.adapter.after_anvil_create(workspace)
         # No WorkspaceGroupSharing objects were created.
         self.assertEqual(WorkspaceGroupSharing.objects.count(), 0)
+
+    def test_after_anvil_import(self):
+        admins_group = ManagedGroupFactory.create(name="TEST_GREGOR_DCC_ADMINS")
+        workspace = WorkspaceFactory.create(
+            billing_project__name="bar", name="foo", workspace_type=self.adapter.get_type()
+        )
+        # API response for admin group workspace owner.
+        acls = [
+            {
+                "email": "TEST_GREGOR_DCC_ADMINS@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point + "/api/workspaces/bar/foo/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_import(workspace)
+        # Check for WorkspaceGroupSharing.
+        self.assertEqual(WorkspaceGroupSharing.objects.count(), 1)
+        sharing = WorkspaceGroupSharing.objects.first()
+        self.assertEqual(sharing.workspace, workspace)
+        self.assertEqual(sharing.group, admins_group)
+        self.assertEqual(sharing.access, WorkspaceGroupSharing.OWNER)
+        self.assertTrue(sharing.can_compute)
+
+    @override_settings(ANVIL_DCC_ADMINS_GROUP_NAME="foobar")
+    def test_after_anvil_import_different_admins_group(self):
+        admins_group = ManagedGroupFactory.create(name="foobar")
+        workspace = WorkspaceFactory.create(
+            billing_project__name="bar", name="foo", workspace_type=self.adapter.get_type()
+        )
+        # API response for admin group workspace owner.
+        acls = [
+            {
+                "email": "foobar@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point + "/api/workspaces/bar/foo/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_import(workspace)
+        # Check for WorkspaceGroupSharing.
+        self.assertEqual(WorkspaceGroupSharing.objects.count(), 1)
+        sharing = WorkspaceGroupSharing.objects.first()
+        self.assertEqual(sharing.workspace, workspace)
+        self.assertEqual(sharing.group, admins_group)
+        self.assertEqual(sharing.access, WorkspaceGroupSharing.OWNER)
+        self.assertTrue(sharing.can_compute)
+
+    def test_after_anvil_import_no_admins_group(self):
+        workspace = WorkspaceFactory.create(
+            billing_project__name="bar", name="foo", workspace_type=self.adapter.get_type()
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_import(workspace)
+        # No WorkspaceGroupSharing objects were created.
+        self.assertEqual(WorkspaceGroupSharing.objects.count(), 0)
+
+    def test_after_anvil_import_already_shared(self):
+        admins_group = ManagedGroupFactory.create(name="TEST_GREGOR_DCC_ADMINS")
+        workspace = WorkspaceFactory.create(workspace_type=self.adapter.get_type())
+        WorkspaceGroupSharingFactory.create(
+            workspace=workspace,
+            group=admins_group,
+            access=WorkspaceGroupSharing.OWNER,
+            can_compute=True,
+        )
+        # No API call - record already exists.
+        # Run the adapter method.
+        self.adapter.after_anvil_import(workspace)
+        # Check for WorkspaceGroupSharing.
+        self.assertEqual(WorkspaceGroupSharing.objects.count(), 1)
+        sharing = WorkspaceGroupSharing.objects.first()
+        self.assertEqual(sharing.workspace, workspace)
+        self.assertEqual(sharing.group, admins_group)
+        self.assertEqual(sharing.access, WorkspaceGroupSharing.OWNER)
+        self.assertTrue(sharing.can_compute)

--- a/gregor_django/gregor_anvil/tests/test_adapters.py
+++ b/gregor_django/gregor_anvil/tests/test_adapters.py
@@ -3,6 +3,7 @@ from anvil_consortium_manager.adapters.default import DefaultWorkspaceAdapter
 from anvil_consortium_manager.models import Account, WorkspaceGroupSharing
 from anvil_consortium_manager.tests.factories import (
     AccountFactory,
+    GroupGroupMembership,
     ManagedGroupFactory,
     WorkspaceFactory,
     WorkspaceGroupSharingFactory,
@@ -239,3 +240,55 @@ class WorkspaceAdminSharingAdapterMixin(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(sharing.group, admins_group)
         self.assertEqual(sharing.access, WorkspaceGroupSharing.OWNER)
         self.assertTrue(sharing.can_compute)
+
+
+class ManagedGroupAdapterTest(AnVILAPIMockTestMixin, TestCase):
+    """Tests for the custom PRIMED ManagedGroupAdapter."""
+
+    def setUp(self):
+        super().setUp()
+        self.adapter = adapters.ManagedGroupAdapter()
+
+    def test_after_anvil_create(self):
+        admins_group = ManagedGroupFactory.create(name="TEST_GREGOR_DCC_ADMINS")
+        managed_group = ManagedGroupFactory.create(name="test-group")
+        # API response for PRIMED_ADMINS membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + "/api/groups/v1/test-group/admin/TEST_GREGOR_DCC_ADMINS@firecloud.org",
+            status=204,
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_create(managed_group)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupGroupMembership.objects.count(), 1)
+        membership = GroupGroupMembership.objects.first()
+        self.assertEqual(membership.parent_group, managed_group)
+        self.assertEqual(membership.child_group, admins_group)
+        self.assertEqual(membership.role, GroupGroupMembership.ADMIN)
+
+    @override_settings(ANVIL_CC_ADMINS_GROUP_NAME="foobar")
+    def test_after_anvil_create_different_admins_group(self):
+        admins_group = ManagedGroupFactory.create(name="foobar")
+        managed_group = ManagedGroupFactory.create(name="test-group")
+        # API response for PRIMED_ADMINS membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + "/api/groups/v1/test-group/admin/foobar@firecloud.org",
+            status=204,
+        )
+        # Run the adapter method.
+        self.adapter.after_anvil_create(managed_group)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupGroupMembership.objects.count(), 1)
+        membership = GroupGroupMembership.objects.first()
+        self.assertEqual(membership.parent_group, managed_group)
+        self.assertEqual(membership.child_group, admins_group)
+        self.assertEqual(membership.role, GroupGroupMembership.ADMIN)
+
+    def test_after_anvil_create_no_admins_group(self):
+        managed_group = ManagedGroupFactory.create(name="test-group")
+        # Run the adapter method.
+        self.adapter.after_anvil_create(managed_group)
+        # No WorkspaceGroupSharing objects were created.
+        self.assertEqual(GroupGroupMembership.objects.count(), 0)

--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -1161,6 +1161,8 @@ class UploadWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             Permission.objects.get(codename=acm_models.AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME)
         )
         self.workspace_type = "upload"
+        # Create the admins group.
+        self.admins_group = acm_factories.ManagedGroupFactory.create(name=settings.ANVIL_DCC_ADMINS_GROUP_NAME)
 
     def get_url(self, *args):
         """Get the url for the view being tested."""
@@ -1183,6 +1185,23 @@ class UploadWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             url,
             status=self.api_success_code,
             match=[responses.matchers.json_params_matcher(json_data)],
+        )
+        # API response for GREGOR admins workspace owner.
+        acls = [
+            {
+                "email": "TEST_GREGOR_DCC_ADMINS@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point
+            + "/api/workspaces/test-billing-project/test-workspace/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
         )
         self.client.force_login(self.user)
         response = self.client.post(
@@ -1401,6 +1420,8 @@ class ResourceWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             Permission.objects.get(codename=acm_models.AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME)
         )
         self.workspace_type = "resource"
+        # Create the admins group.
+        self.admins_group = acm_factories.ManagedGroupFactory.create(name=settings.ANVIL_DCC_ADMINS_GROUP_NAME)
 
     def get_url(self, *args):
         """Get the url for the view being tested."""
@@ -1420,6 +1441,23 @@ class ResourceWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             url,
             status=self.api_success_code,
             match=[responses.matchers.json_params_matcher(json_data)],
+        )
+        # API response for GREGOR admins workspace owner.
+        acls = [
+            {
+                "email": "TEST_GREGOR_DCC_ADMINS@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point
+            + "/api/workspaces/test-billing-project/test-workspace/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
         )
         self.client.force_login(self.user)
         response = self.client.post(
@@ -1512,6 +1550,8 @@ class TemplateWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             Permission.objects.get(codename=acm_models.AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME)
         )
         self.workspace_type = "template"
+        # Create the admins group.
+        self.admins_group = acm_factories.ManagedGroupFactory.create(name=settings.ANVIL_DCC_ADMINS_GROUP_NAME)
 
     def get_url(self, *args):
         """Get the url for the view being tested."""
@@ -1531,6 +1571,23 @@ class TemplateWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             url,
             status=self.api_success_code,
             match=[responses.matchers.json_params_matcher(json_data)],
+        )
+        # API response for GREGOR admins workspace owner.
+        acls = [
+            {
+                "email": "TEST_GREGOR_DCC_ADMINS@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point
+            + "/api/workspaces/test-billing-project/test-workspace/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
         )
         self.client.force_login(self.user)
         response = self.client.post(
@@ -1974,6 +2031,8 @@ class ExchangeWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             Permission.objects.get(codename=acm_models.AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME)
         )
         self.workspace_type = "exchange"
+        # Create the admins group.
+        self.admins_group = acm_factories.ManagedGroupFactory.create(name=settings.ANVIL_DCC_ADMINS_GROUP_NAME)
 
     def get_url(self, *args):
         """Get the url for the view being tested."""
@@ -1994,6 +2053,23 @@ class ExchangeWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             url,
             status=self.api_success_code,
             match=[responses.matchers.json_params_matcher(json_data)],
+        )
+        # API response for GREGOR admins workspace owner.
+        acls = [
+            {
+                "email": "TEST_GREGOR_DCC_ADMINS@firecloud.org",
+                "accessLevel": "OWNER",
+                "canShare": False,
+                "canCompute": True,
+            }
+        ]
+        self.anvil_response_mock.add(
+            responses.PATCH,
+            self.api_client.rawls_entry_point
+            + "/api/workspaces/test-billing-project/test-workspace/acl?inviteUsersNotFound=false",
+            status=200,
+            match=[responses.matchers.json_params_matcher(acls)],
+            json={"invitesSent": {}, "usersNotFound": {}, "usersUpdated": acls},
         )
         self.client.force_login(self.user)
         response = self.client.post(

--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -2093,3 +2093,50 @@ class ExchangeWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_workspace_data = models.ExchangeWorkspace.objects.latest("pk")
         self.assertEqual(new_workspace_data.workspace, new_workspace)
         self.assertEqual(new_workspace_data.research_center, research_center)
+
+
+class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
+    """Tests for custom ManagedGroup behavior."""
+
+    def get_url(self, *args):
+        """Get the url for the view being tested."""
+        return reverse("anvil_consortium_manager:managed_groups:new", args=args)
+
+    def setUp(self):
+        """Set up test class."""
+        # The superclass uses the responses package to mock API responses.
+        super().setUp()
+        self.factory = RequestFactory()
+        # Create a user with both view and edit permissions.
+        self.user = User.objects.create_user(username="test", password="test")
+        self.user.user_permissions.add(
+            Permission.objects.get(codename=acm_models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME)
+        )
+        self.user.user_permissions.add(
+            Permission.objects.get(codename=acm_models.AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME)
+        )
+        # Create the admins group.
+        self.admins_group = acm_factories.ManagedGroupFactory.create(name="TEST_GREGOR_DCC_ADMINS")
+
+    def test_cc_admins_membership(self):
+        """The after_anvil_create method is run after a managed group is created."""
+        # API response for group creation.
+        api_url = self.api_client.sam_entry_point + "/api/groups/v1/test-group"
+        self.anvil_response_mock.add(responses.POST, api_url, status=201)
+        # API response for auth domain PRIMED_ADMINS membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + "/api/groups/v1/test-group/admin/TEST_GREGOR_DCC_ADMINS@firecloud.org",
+            status=204,
+        )
+        # Submit the form to django.
+        self.client.force_login(self.user)
+        response = self.client.post(self.get_url(), {"name": "test-group"})
+        self.assertEqual(response.status_code, 302)
+        # Check that the admin group was added.
+        new_group = acm_models.ManagedGroup.objects.latest("pk")
+        self.assertEqual(acm_models.GroupGroupMembership.objects.count(), 1)
+        membership = acm_models.GroupGroupMembership.objects.first()
+        self.assertEqual(membership.parent_group, new_group)
+        self.assertEqual(membership.child_group, self.admins_group)
+        self.assertEqual(membership.role, acm_models.GroupGroupMembership.ADMIN)


### PR DESCRIPTION
- Add Workspace adapter methods to automatically share any workspaces that was created or imported with the DCC admins group
- Add ManagedGroup adapter methods to automatically add the DCC admins group to any managed group created via the ManagedGroupCreate view