### PR TITLE
Do not schedule combine-prs workflow

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -1,8 +1,6 @@
 name: Combine PRs
 
 on:
-  schedule:
-    - cron: '0 8 * * 1' # Monday at 08:00 UTC
   workflow_dispatch: # allows you to manually trigger the workflow
 
 # The minimum permissions required to run this Action


### PR DESCRIPTION
It is better to review the dependabot PRs, close any that we do not want included in the combined update, and then run the combine-prs workflow manually (via workflow dispatch). This way we won't inadvertently get updates that we don't want (e.g., a passing PR that updates to django-5.0).