### PR TITLE
Upload workspace audit - user feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           name: coverage-data-${{ strategy.job-index }}
           path: .coverage-${{ strategy.job-index }}
+          if-no-files-found: error
 
   coverage:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Run tests
         run:  |
           pytest --cov=gregor_django -n auto
-          mv .coverage .coverage-${{ strategy.job-index }}
+          mv .coverage coverage-${{ strategy.job-index }}
 
       - name: List files for debugging purposes
         run: ls -lhta
@@ -102,7 +102,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ strategy.job-index }}
-          path: .coverage-${{ strategy.job-index }}
+          path: coverage-${{ strategy.job-index }}
           if-no-files-found: error
 
   coverage:
@@ -130,7 +130,7 @@ jobs:
 
       - name: Merge coverage files
         run: |
-          python -m coverage combine ./artifacts/coverage-data*/.coverage-*
+          python -m coverage combine ./artifacts/coverage-data*/coverage-*
           python -m coverage xml
           ls -la .coverage*
 

--- a/gregor_django/gregor_anvil/audit/upload_workspace_sharing_audit.py
+++ b/gregor_django/gregor_anvil/audit/upload_workspace_sharing_audit.py
@@ -20,18 +20,6 @@ class UploadWorkspaceSharingAuditResult(GREGoRAuditResult):
     action: str = None
     current_sharing_instance: WorkspaceGroupSharing = None
 
-    def get_action_url(self):
-        """The URL that handles the action needed."""
-        # return reverse(
-        #     "gregor_anvil:audit:upload_workspaces:sharing:resolve",
-        #     args=[
-        #         self.dbgap_application.dbgap_project_id,
-        #         self.workspace.workspace.billing_project.name,
-        #         self.workspace.workspace.name,
-        #     ],
-        # )
-        return ""
-
     def get_table_dictionary(self):
         """Return a dictionary that can be used to populate an instance of `dbGaPDataSharingSnapshotAuditTable`."""
         can_compute = None
@@ -44,7 +32,6 @@ class UploadWorkspaceSharingAuditResult(GREGoRAuditResult):
             "can_compute": can_compute,
             "note": self.note,
             "action": self.action,
-            "action_url": self.get_action_url(),
         }
         return row
 
@@ -52,8 +39,6 @@ class UploadWorkspaceSharingAuditResult(GREGoRAuditResult):
 @dataclass
 class VerifiedShared(UploadWorkspaceSharingAuditResult):
     """Audit results class for when Sharing has been verified."""
-
-    is_shared: bool = True
 
     def __str__(self):
         return f"Verified sharing: {self.note}"
@@ -63,8 +48,6 @@ class VerifiedShared(UploadWorkspaceSharingAuditResult):
 class VerifiedNotShared(UploadWorkspaceSharingAuditResult):
     """Audit results class for when no Sharing has been verified."""
 
-    is_shared: bool = False
-
     def __str__(self):
         return f"Verified not shared: {self.note}"
 
@@ -73,7 +56,6 @@ class VerifiedNotShared(UploadWorkspaceSharingAuditResult):
 class ShareAsReader(UploadWorkspaceSharingAuditResult):
     """Audit results class for when Sharing should be granted as a reader."""
 
-    is_shared: bool = False
     action: str = "Share as reader"
 
     def __str__(self):
@@ -84,7 +66,6 @@ class ShareAsReader(UploadWorkspaceSharingAuditResult):
 class ShareAsWriter(UploadWorkspaceSharingAuditResult):
     """Audit results class for when Sharing should be granted as a writer."""
 
-    is_shared: bool = False
     action: str = "Share as writer"
 
     def __str__(self):
@@ -95,7 +76,6 @@ class ShareAsWriter(UploadWorkspaceSharingAuditResult):
 class ShareAsOwner(UploadWorkspaceSharingAuditResult):
     """Audit results class for when Sharing should be granted as an owner."""
 
-    is_shared: bool = False
     action: str = "Share as owner"
 
     def __str__(self):
@@ -106,7 +86,6 @@ class ShareAsOwner(UploadWorkspaceSharingAuditResult):
 class ShareWithCompute(UploadWorkspaceSharingAuditResult):
     """Audit results class for when Sharing should be granted with compute access."""
 
-    is_shared: bool = False
     action: str = "Share with compute"
 
     def __str__(self):
@@ -117,7 +96,6 @@ class ShareWithCompute(UploadWorkspaceSharingAuditResult):
 class StopSharing(UploadWorkspaceSharingAuditResult):
     """Audit results class for when Sharing should be removed for a known reason."""
 
-    is_shared: bool = True
     action: str = "Stop sharing"
 
     def __str__(self):
@@ -136,11 +114,9 @@ class UploadWorkspaceSharingAuditTable(tables.Table):
 
     workspace = tables.Column(linkify=True)
     managed_group = tables.Column(linkify=True)
-    # is_shared = tables.Column()
     access = tables.Column(verbose_name="Current access")
     can_compute = BooleanIconColumn(show_false_icon=True, null=True, true_color="green", false_color="black")
     note = tables.Column()
-    # action = tables.Column()
     action = tables.TemplateColumn(
         template_name="gregor_anvil/snippets/upload_workspace_sharing_audit_action_button.html"
     )

--- a/gregor_django/gregor_anvil/audit/upload_workspace_sharing_audit.py
+++ b/gregor_django/gregor_anvil/audit/upload_workspace_sharing_audit.py
@@ -34,11 +34,14 @@ class UploadWorkspaceSharingAuditResult(GREGoRAuditResult):
 
     def get_table_dictionary(self):
         """Return a dictionary that can be used to populate an instance of `dbGaPDataSharingSnapshotAuditTable`."""
+        can_compute = None
+        if self.current_sharing_instance and self.current_sharing_instance.access != WorkspaceGroupSharing.READER:
+            can_compute = self.current_sharing_instance.can_compute
         row = {
             "workspace": self.workspace,
             "managed_group": self.managed_group,
             "access": self.current_sharing_instance.access if self.current_sharing_instance else None,
-            "can_compute": self.current_sharing_instance.can_compute if self.current_sharing_instance else None,
+            "can_compute": can_compute,
             "note": self.note,
             "action": self.action,
             "action_url": self.get_action_url(),

--- a/gregor_django/gregor_anvil/audit/upload_workspace_sharing_audit.py
+++ b/gregor_django/gregor_anvil/audit/upload_workspace_sharing_audit.py
@@ -135,7 +135,7 @@ class UploadWorkspaceSharingAuditTable(tables.Table):
     managed_group = tables.Column(linkify=True)
     # is_shared = tables.Column()
     access = tables.Column(verbose_name="Current access")
-    can_compute = BooleanIconColumn(show_false_icon=True, null=True)
+    can_compute = BooleanIconColumn(show_false_icon=True, null=True, true_color="green", false_color="black")
     note = tables.Column()
     # action = tables.Column()
     action = tables.TemplateColumn(

--- a/gregor_django/gregor_anvil/tests/test_audit.py
+++ b/gregor_django/gregor_anvil/tests/test_audit.py
@@ -162,6 +162,67 @@ class GREGoRAuditTest(TestCase):
         self.assertEqual(table.rows[0].get_cell("value"), "c")
 
 
+class UploadWorkspaceSharingAuditTableTest(TestCase):
+    """General tests of the UploadWorkspaceSharingAuditTable class."""
+
+    def test_no_rows(self):
+        """Table works with no rows."""
+        table = upload_workspace_sharing_audit.UploadWorkspaceSharingAuditTable([])
+        self.assertIsInstance(table, upload_workspace_sharing_audit.UploadWorkspaceSharingAuditTable)
+        self.assertEqual(len(table.rows), 0)
+
+    def test_one_row(self):
+        """Table works with one row."""
+        upload_workspace = factories.UploadWorkspaceFactory.create()
+        group = ManagedGroupFactory.create()
+        WorkspaceGroupSharingFactory.create(
+            workspace=upload_workspace.workspace, group=group, access=WorkspaceGroupSharing.READER
+        )
+        data = [
+            {
+                "workspace": upload_workspace,
+                "managed_group": group,
+                "access": WorkspaceGroupSharing.READER,
+                "can_compute": None,
+                "note": "a note",
+                "action": "",
+            },
+        ]
+        table = upload_workspace_sharing_audit.UploadWorkspaceSharingAuditTable(data)
+        self.assertIsInstance(table, upload_workspace_sharing_audit.UploadWorkspaceSharingAuditTable)
+        self.assertEqual(len(table.rows), 1)
+
+    def test_two_rows(self):
+        """Table works with two rows."""
+        upload_workspace = factories.UploadWorkspaceFactory.create()
+        group_1 = ManagedGroupFactory.create()
+        group_2 = ManagedGroupFactory.create()
+        WorkspaceGroupSharingFactory.create(
+            workspace=upload_workspace.workspace, group=group_1, access=WorkspaceGroupSharing.READER
+        )
+        data = [
+            {
+                "workspace": upload_workspace,
+                "managed_group": group_1,
+                "access": WorkspaceGroupSharing.READER,
+                "can_compute": None,
+                "note": "a note",
+                "action": "",
+            },
+            {
+                "workspace": upload_workspace,
+                "managed_group": group_2,
+                "access": None,
+                "can_compute": None,
+                "note": "a note",
+                "action": "",
+            },
+        ]
+        table = upload_workspace_sharing_audit.UploadWorkspaceSharingAuditTable(data)
+        self.assertIsInstance(table, upload_workspace_sharing_audit.UploadWorkspaceSharingAuditTable)
+        self.assertEqual(len(table.rows), 2)
+
+
 class UploadWorkspaceSharingAuditTest(TestCase):
     """General tests of the `UploadWorkspaceSharingAudit` class."""
 
@@ -3858,6 +3919,68 @@ class UploadWorkspaceSharingAuditPastCycleAfterCombinedWorkspaceSharedTest(TestC
         self.assertEqual(record.managed_group, self.other_group)
         self.assertEqual(record.current_sharing_instance, sharing)
         self.assertEqual(record.note, upload_workspace_sharing_audit.UploadWorkspaceSharingAudit.OTHER_GROUP_NO_ACCESS)
+
+
+class UploadWorkspaceAuthDomainAuditTableTest(TestCase):
+    """General tests of the UploadWorkspaceAuthDomainAuditTable class."""
+
+    def test_no_rows(self):
+        """Table works with no rows."""
+        table = upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditTable([])
+        self.assertIsInstance(table, upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditTable)
+        self.assertEqual(len(table.rows), 0)
+
+    def test_one_row(self):
+        """Table works with one row."""
+        upload_workspace = factories.UploadWorkspaceFactory.create()
+        group = ManagedGroupFactory.create()
+        GroupGroupMembershipFactory.create(
+            parent_group=upload_workspace.workspace.authorization_domains.first(),
+            child_group=group,
+            role=GroupGroupMembership.MEMBER,
+        )
+        data = [
+            {
+                "workspace": upload_workspace,
+                "managed_group": group,
+                "role": GroupGroupMembership.MEMBER,
+                "note": "a note",
+                "action": "",
+            },
+        ]
+        table = upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditTable(data)
+        self.assertIsInstance(table, upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditTable)
+        self.assertEqual(len(table.rows), 1)
+
+    def test_two_rows(self):
+        """Table works with two rows."""
+        upload_workspace = factories.UploadWorkspaceFactory.create()
+        group_1 = ManagedGroupFactory.create()
+        group_2 = ManagedGroupFactory.create()
+        GroupGroupMembershipFactory.create(
+            parent_group=upload_workspace.workspace.authorization_domains.first(),
+            child_group=group_1,
+            role=GroupGroupMembership.MEMBER,
+        )
+        data = [
+            {
+                "workspace": upload_workspace,
+                "managed_group": group_1,
+                "role": GroupGroupMembership.MEMBER,
+                "note": "a note",
+                "action": "",
+            },
+            {
+                "workspace": upload_workspace,
+                "managed_group": group_2,
+                "role": None,
+                "note": "a note",
+                "action": "",
+            },
+        ]
+        table = upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditTable(data)
+        self.assertIsInstance(table, upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditTable)
+        self.assertEqual(len(table.rows), 2)
 
 
 class UploadWorkspaceAuthDomainAuditTest(TestCase):

--- a/gregor_django/gregor_anvil/tests/test_audit.py
+++ b/gregor_django/gregor_anvil/tests/test_audit.py
@@ -4013,7 +4013,7 @@ class UploadWorkspaceAuthDomainAuditResultTest(TestCase):
             child_group=group,
             role=GroupGroupMembership.ADMIN,
         )
-        instance = upload_workspace_sharing_audit.UploadWorkspaceSharingAuditResult(
+        instance = upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditResult(
             workspace=upload_workspace,
             managed_group=group,
             current_membership_instance=membership,
@@ -4030,7 +4030,7 @@ class UploadWorkspaceAuthDomainAuditResultTest(TestCase):
             child_group=group,
             role=GroupGroupMembership.MEMBER,
         )
-        instance = upload_workspace_sharing_audit.UploadWorkspaceSharingAuditResult(
+        instance = upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditResult(
             workspace=upload_workspace,
             managed_group=group,
             current_membership_instance=membership,
@@ -4042,7 +4042,7 @@ class UploadWorkspaceAuthDomainAuditResultTest(TestCase):
     def test_not_member(self):
         upload_workspace = factories.UploadWorkspaceFactory.create(upload_cycle__is_future=True)
         group = ManagedGroupFactory.create()
-        instance = upload_workspace_sharing_audit.UploadWorkspaceSharingAuditResult(
+        instance = upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAuditResult(
             workspace=upload_workspace,
             managed_group=group,
             current_membership_instance=None,

--- a/gregor_django/gregor_anvil/tests/test_views.py
+++ b/gregor_django/gregor_anvil/tests/test_views.py
@@ -2693,6 +2693,12 @@ class UploadWorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertNotEqual(table.rows[0].get_cell_value("action"), "&mdash;")
 
+    def test_title(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url())
+        # self.assertContains(response, str(self.upload_workspace))
+        self.assertIn("all upload workspaces", response.content.decode().lower())
+
 
 class UploadWorkspaceSharingAuditByWorkspaceTest(AnVILAPIMockTestMixin, TestCase):
     """Tests for the UploadWorkspaceSharingAuditByWorkspace view."""
@@ -3059,6 +3065,17 @@ class UploadWorkspaceSharingAuditByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
         )
         self.assertNotEqual(table.rows[0].get_cell_value("action"), "&mdash;")
 
+    def test_title(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(
+                self.upload_workspace.workspace.billing_project.name,
+                self.upload_workspace.workspace.name,
+            )
+        )
+        self.assertContains(response, str(self.upload_workspace))
+        # self.assertNotIn("all upload workspaces", response.content.decode().lower())
+
 
 class UploadWorkspaceSharingAuditByUploadCycleTest(AnVILAPIMockTestMixin, TestCase):
     """Tests for the UploadWorkspaceSharingAuditByUploadCycle view."""
@@ -3392,6 +3409,12 @@ class UploadWorkspaceSharingAuditByUploadCycleTest(AnVILAPIMockTestMixin, TestCa
             upload_workspace_sharing_audit.UploadWorkspaceSharingAudit.OTHER_GROUP_NO_ACCESS,
         )
         self.assertNotEqual(table.rows[0].get_cell_value("action"), "&mdash;")
+
+    def test_title(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.upload_cycle.cycle))
+        self.assertContains(response, str(self.upload_cycle))
+        self.assertNotIn("all upload workspaces", response.content.decode().lower())
 
 
 class UploadWorkspaceSharingAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
@@ -4847,6 +4870,12 @@ class UploadWorkspaceAuthDomainAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertNotEqual(table.rows[0].get_cell_value("action"), "&mdash;")
 
+    def test_title(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url())
+        # self.assertContains(response, str(self.upload_workspace))
+        self.assertIn("all upload workspaces", response.content.decode().lower())
+
 
 class UploadWorkspaceAuthDomainAuditByWorkspaceTest(AnVILAPIMockTestMixin, TestCase):
     """Tests for the UploadWorkspaceAuthDomainAuditByWorkspace view."""
@@ -5225,6 +5254,17 @@ class UploadWorkspaceAuthDomainAuditByWorkspaceTest(AnVILAPIMockTestMixin, TestC
         )
         self.assertNotEqual(table.rows[0].get_cell_value("action"), "&mdash;")
 
+    def test_title(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(
+                self.upload_workspace.workspace.billing_project.name,
+                self.upload_workspace.workspace.name,
+            )
+        )
+        self.assertContains(response, str(self.upload_workspace))
+        self.assertNotIn("all upload workspaces", response.content.decode().lower())
+
 
 class UploadWorkspaceAuthDomainAuditByUploadCycleTest(AnVILAPIMockTestMixin, TestCase):
     """Tests for the UploadWorkspaceSharingAuditByUploadCycle view."""
@@ -5565,6 +5605,12 @@ class UploadWorkspaceAuthDomainAuditByUploadCycleTest(AnVILAPIMockTestMixin, Tes
             upload_workspace_auth_domain_audit.UploadWorkspaceAuthDomainAudit.DCC_ADMINS,
         )
         self.assertNotEqual(table.rows[0].get_cell_value("action"), "&mdash;")
+
+    def test_title(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.upload_cycle.cycle))
+        self.assertContains(response, str(self.upload_cycle))
+        self.assertNotIn("all upload workspaces", response.content.decode().lower())
 
 
 class UploadWorkspaceAuthDomainAuditResolveTest(AnVILAPIMockTestMixin, TestCase):

--- a/gregor_django/templates/gregor_anvil/snippets/upload_workspace_auth_domain_audit_explanation.html
+++ b/gregor_django/templates/gregor_anvil/snippets/upload_workspace_auth_domain_audit_explanation.html
@@ -12,12 +12,26 @@
                 This audit checks that auth domain membership is appropriate for the current point in the upload cycle.
                 Membership is expected to be as follows.
                 <ul>
+                    <li>Before the upload cycle begins:</li>
+                    <ul>
+                      <li>GREGOR_DCC_ADMINS (as admin)</li>
+                      <li>GREGOR_DCC_WRITERS</li>
+                      <li>GREGOR_DCC_MEMBERS</li>
+                    </ul>
                     <li>Before the combined workspace is completed:</li>
                     <ul>
                       <li>GREGOR_DCC_ADMINS (as admin)</li>
                       <li>GREGOR_DCC_WRITERS</li>
                       <li>GREGOR_DCC_MEMBERS</li>
                       <li>The upload group for the Research Center associated with this upload workspace</li>
+                      <li>The member group for the Research Center associated with this upload workspace</li>
+                      <li>The non-member group for the Research Center associated with this upload workspace</li>
+                    </ul>
+                    <li>After QC has been completed:</li>
+                    <ul>
+                      <li>GREGOR_DCC_ADMINS (as admin)</li>
+                      <li>GREGOR_DCC_WRITERS</li>
+                      <li>GREGOR_DCC_MEMBERS</li>
                       <li>The member group for the Research Center associated with this upload workspace</li>
                       <li>The non-member group for the Research Center associated with this upload workspace</li>
                     </ul>

--- a/gregor_django/templates/gregor_anvil/snippets/upload_workspace_sharing_audit_explanation.html
+++ b/gregor_django/templates/gregor_anvil/snippets/upload_workspace_sharing_audit_explanation.html
@@ -36,7 +36,7 @@
 
                 <li><b>Errors</b></li>
                 <ul>
-                  <li>The workspace has been shared with an unexpected group as an "OWNER".</li>
+                  <li>The workspace has been shared with an unexpected group.</li>
                 </ul>
               </ul>
             </p>

--- a/gregor_django/templates/gregor_anvil/upload_workspace_auth_domain_audit.html
+++ b/gregor_django/templates/gregor_anvil/upload_workspace_auth_domain_audit.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<h1>Upload workspace auth domain audit: {{ object }} </h1>
+<h1>Upload workspace auth domain audit: {% if object %} {{ object }} {% else %} all Upload Workspaces{% endif %} </h1>
 
 <div class="my-3 p-3 bg-light border rounded shadow-sm">
     <p>

--- a/gregor_django/templates/gregor_anvil/upload_workspace_sharing_audit.html
+++ b/gregor_django/templates/gregor_anvil/upload_workspace_sharing_audit.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<h1>Upload workspace sharing audit: {{ object }} </h1>
+<h1>Upload workspace sharing audit: {% if object %}{{ object }}{% else %} all Upload Workspaces{% endif %} </h1>
 
 <div class="my-3 p-3 bg-light border rounded shadow-sm">
     <p>


### PR DESCRIPTION
- Only show the can_compute icon for WRITER and OWNER levels
- Color the false icons black instead of red, since they don't indicate errors
- Clean up audit explanations
- Clean up unused code
- Add tests for audit result dataclasses