### PR TITLE
Add auth cycle error logging 

### DIFF
--- a/gregor_django/templates/socialaccount/authentication_error.html
+++ b/gregor_django/templates/socialaccount/authentication_error.html
@@ -1,0 +1,15 @@
+{% extends "socialaccount/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Social Network Login Failure" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Social Network Login Failure" %}</h1>
+
+<p>{% trans "Sorry. An error occurred while attempting to login via your social network account." %}</p>
+
+<p class='alert alert-error'>
+    Authentication error code: {{ auth_error.code }}, Error: {{ auth_error.exception }}
+</p>
+{% endblock %}

--- a/gregor_django/users/adapters.py
+++ b/gregor_django/users/adapters.py
@@ -185,3 +185,11 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         self.update_user_research_centers(user, extra_data)
         self.update_user_partner_groups(user, extra_data)
         self.update_user_groups(user, extra_data)
+
+    def authentication_error(self, request, provider_id, error, exception, extra_context):
+        """
+        Invoked when there is an error in auth cycle.
+        Log so we know what is going on.
+        """
+        logger.error(f"[SocialAccountAdapter:authentication_error] Error {error} Exception: {exception}")
+        super().authentication_error(request, provider_id, error, exception, extra_context)


### PR DESCRIPTION
Add logging to our social account adapter so we can capture when there are cert or other login cycle issues.
Update auth error template to display more information about the login error.