### PR TITLE
Use new version of update-requirements-files action

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.10"
 
       - name: Update requirements files
-        uses: UW-GAC/pip-tools-actions/update-requirements-files@v0.1
+        uses: UW-GAC/pip-tools-actions/update-requirements-files@v0.2
         with:
           requirements_files:  |-
             requirements/requirements.in


### PR DESCRIPTION
This fixes an issue with pip-tools and pip versions, where pip-copmile was adding absolute paths when run with a pip version of >=24.3.