### PR TITLE
Maint/favicon notfound

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -298,6 +298,7 @@ LOGIN_REQUIRED_IGNORE_VIEW_NAMES = [
     "socialaccount_signup",
     "admin:index",
     "admin:login",
+    "favicon"
 ]
 
 # django-dbbackup

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -298,7 +298,7 @@ LOGIN_REQUIRED_IGNORE_VIEW_NAMES = [
     "socialaccount_signup",
     "admin:index",
     "admin:login",
-    "favicon"
+    "favicon",
 ]
 
 # django-dbbackup

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,9 +1,11 @@
 from django.conf import settings
 from django.conf.urls.static import static
+from django.templatetags.static import static as static_url_tag
 from django.contrib import admin
 from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
@@ -22,6 +24,7 @@ urlpatterns = [
         "gregor_anvil/",
         include("gregor_django.gregor_anvil.urls", namespace="gregor_anvil"),
     ),
+    path("favicon.ico", RedirectView.as_view(url=static_url_tag("images/favicons/favicon_1.jpg"), permanent=True), name="favicon"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls.static import static
-from django.templatetags.static import static as static_url_tag
 from django.contrib import admin
+from django.templatetags.static import static as static_url_tag
 from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
@@ -24,7 +24,11 @@ urlpatterns = [
         "gregor_anvil/",
         include("gregor_django.gregor_anvil.urls", namespace="gregor_anvil"),
     ),
-    path("favicon.ico", RedirectView.as_view(url=static_url_tag("images/favicons/favicon_1.jpg"), permanent=True), name="favicon"),
+    path(
+        "favicon.ico",
+        RedirectView.as_view(url=static_url_tag("images/favicons/favicon_1.jpg"), permanent=True),
+        name="favicon",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 


### PR DESCRIPTION
Squash favicon.ico not found errors by adding redirect view to our custom favicon. 
Browsers will still load favicon.ico in some cases even if you specify a different favicon in your html head.