### PR TITLE
Use release-drafter action to draft releases and notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,13 @@
+sort-direction: ascending
+
+categories:
+  - title: "⬆️ Dependencies"
+    labels:
+      - "dependencies"
+      - "update-requirements-files"
+      - "combined-pr"
+
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,114 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - deploy/production
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Get current date
+      id: get-date
+      run: |
+          export CURRENT_DATE=$(TZ=":America/Los_Angeles" date "+%Y-%m-%d")
+          echo "current_date=${CURRENT_DATE}" >> $GITHUB_OUTPUT
+          echo "Current date set to ${CURRENT_DATE}"
+
+    - name: Get number of releases for the current date
+      id: get-release-count
+      run: |
+        export RELEASE_COUNT=$(gh release list \
+          --repo ${{ github.repository }} \
+          --json tagName \
+          --exclude-drafts \
+          --jq "map(select(.tagName | startswith(\"${CURRENT_DATE}\")))|length" \
+          )
+        echo "release_count=${RELEASE_COUNT}" >> $GITHUB_OUTPUT
+        echo "Found ${RELEASE_COUNT} releases"
+      env:
+        CURRENT_DATE: ${{ steps.get-date.outputs.current_date }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Prepare release version
+      id: get-version
+      run: |
+          export VERSION="${CURRENT_DATE}"
+
+          if [ $RELEASE_COUNT -gt 0 ]; then
+            echo "Release already exists for version ${VERSION}"
+            echo "Appending release count to version"
+            export VERSION="${CURRENT_DATE}-${RELEASE_COUNT}"
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version set to ${VERSION}"
+      env:
+        CURRENT_DATE: ${{ steps.get-date.outputs.current_date }}
+        RELEASE_COUNT: ${{ steps.get-release-count.outputs.release_count }}
+
+
+    - name: Check that version doesn't exist
+      id: check-release
+      run: |
+        echo "Checking version ${VERSION}"
+
+        export CHECK=$(gh release list \
+          --repo ${{ github.repository }} \
+          --json tagName \
+          --exclude-drafts \
+          --jq "map(select(.tagName == \"${VERSION}\"))|length" \
+          )
+        echo "Found ${CHECK} releases"
+
+        if [ $CHECK -gt 0 ]; then
+          echo "Release already exists for version ${VERSION}"
+          exit 1
+        fi
+      env:
+        VERSION: ${{ steps.get-version.outputs.version }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check that tag doesn't exist
+      id: check-tag
+      run: |
+        echo "Checking tag for version ${VERSION}"
+
+        # Query the API for this tag.
+        export CHECK=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{ github.repository }}/tags \
+          --jq "map(select(.name  == \"${VERSION}\"))|length" \
+        )
+        echo "Found ${CHECK} tags"
+
+        if [ $CHECK -gt 0 ]; then
+          echo "Tag already exists for version ${VERSION}"
+          exit 1
+        fi
+      env:
+        VERSION: ${{ steps.get-version.outputs.version }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+    - uses: release-drafter/release-drafter@v6
+      with:
+        commitish: deploy/production
+        tag: ${{ steps.get-version.outputs.version }}
+        name: ${{ steps.get-version.outputs.version }}
+        version: ${{ steps.get-version.outputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add the release-drafter action to draft release notes on a commit/merge to deploy/prod
- Name the draft release and tag with the current date (e.g., 2024-12-05) or current with an integer appended (e.g., 2024-12-05-1, 2024-12-05-2, etc) if a release with the date already exists
- Set up config to separate dependency PRs in their own section in the release notes