### PR TITLE
Update to ACM v0.28

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -91,6 +91,7 @@ THIRD_PARTY_APPS = [
 
 LOCAL_APPS = [
     "anvil_consortium_manager",
+    "anvil_consortium_manager.auditor",
     "gregor_django.users.apps.UsersConfig",
     # Your stuff: custom apps go here
     "gregor_django.drupal_oauth_provider",

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -35,7 +35,7 @@ django-extensions  # https://github.com/django-extensions/django-extensions
 # Bootstrap5 templates for crispy-forms
 crispy-bootstrap5  # https://github.com/django-crispy-forms/crispy-bootstrap5
 
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.27.0
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.28
 # Simple history - model history tracking
 django-simple-history
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -52,7 +52,7 @@ django==4.2.17
     #   django-tables2
 django-allauth==65.3.1
     # via -r requirements/requirements.in
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.27.0
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@12120e008e40d1771b574f66ab7534538cc4dc85
     # via -r requirements/requirements.in
 django-autocomplete-light==3.11.0
     # via django-anvil-consortium-manager


### PR DESCRIPTION
This adds the ability to ignore AnVIL audit "not in app" results.