### PR TITLE
Add django db check to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Collect staticfiles
         run: python manage.py collectstatic --noinput --settings=config.settings.test
 
+      - name: Run Django DB config check
+        run: python manage.py check --database default --fail-level WARNING --settings=config.settings.test
+
       - name: Run tests
         run:  |
           pytest --cov=gregor_django -n auto

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -271,6 +271,12 @@ LOGGING = {
     "root": {"level": "DEBUG", "handlers": ["console"]},
 }
 
+# Django silence system check warnings. https://docs.djangoproject.com/en/5.1/ref/checks/#security
+# This check is regarding constraints placed by django-allauth
+# that mysql does not support. https://github.com/pennersr/django-allauth/issues/3385
+# we would need to move to postgres to support this type of constraint with filter
+SILENCED_SYSTEM_CHECKS = ["models.W036"]
+
 # django-maintenance-mode
 MAINTENANCE_MODE_IGNORE_SUPERUSER = True
 MAINTENANCE_MODE_IGNORE_TESTS = True

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -3,7 +3,7 @@ import os
 # default to using dotenv files for all production environements
 os.environ["DJANGO_READ_DOT_ENV_FILE"] = "True"
 from .base import *  # noqa
-from .base import env  # noqa
+from .base import SILENCED_SYSTEM_CHECKS, env  # noqa
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool("DJANGO_SECURE_CONTENT_TYPE_NOSNIFF", def
 # Since we have disabled HSTS above we get a warning when running check --deploy
 # we are manually silencing this as we have verified apache is enforcing
 # https://docs.djangoproject.com/en/dev/ref/checks/#security
-SILENCED_SYSTEM_CHECKS = ["security.W004"]
+SILENCED_SYSTEM_CHECKS += ["security.W004"]
 # STATIC
 # ------------------------
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"


### PR DESCRIPTION
Fail on warnings. Ignore current warnings that we are aware of. Optimally we could ignore the specific issue and not a class of warnings but django does not currently support that. 