### PR TITLE
Automatically add accounts to members groups

### DIFF
--- a/gregor_django/gregor_anvil/adapters.py
+++ b/gregor_django/gregor_anvil/adapters.py
@@ -73,6 +73,8 @@ class AccountAdapter(BaseAccountAdapter):
     account_verification_notification_email = "gregorconsortium@uw.edu"
     account_verification_notification_template = "gregor_anvil/account_notification_email.html"
 
+    after_account_verification_change_reason = "added automatically after account verification"
+
     def get_autocomplete_queryset(self, queryset, q):
         """Filter to Accounts where the email or the associated user name matches the query `q`."""
         if q:
@@ -107,6 +109,7 @@ class AccountAdapter(BaseAccountAdapter):
                     role=GroupAccountMembership.MEMBER,
                 )
                 membership.full_clean()
+                membership._change_reason = self.after_account_verification_change_reason
                 membership.save()
                 membership.anvil_create()
 

--- a/gregor_django/gregor_anvil/adapters.py
+++ b/gregor_django/gregor_anvil/adapters.py
@@ -71,6 +71,7 @@ class AccountAdapter(BaseAccountAdapter):
     account_link_verify_redirect = "users:redirect"
     account_link_email_subject = "Verify your AnVIL account email"
     account_verification_notification_email = "gregorconsortium@uw.edu"
+    account_verification_notification_template = "gregor_anvil/account_notification_email.html"
 
     def get_autocomplete_queryset(self, queryset, q):
         """Filter to Accounts where the email or the associated user name matches the query `q`."""
@@ -108,6 +109,14 @@ class AccountAdapter(BaseAccountAdapter):
                 membership.full_clean()
                 membership.save()
                 membership.anvil_create()
+
+    def get_account_verification_notification_context(self, account):
+        """Get the context for the account verification notification email."""
+        context = super().get_account_verification_notification_context(account)
+        # Add the list of groups that the account is already in.
+        memberships = GroupAccountMembership.objects.filter(account=account)
+        context["memberships"] = memberships
+        return context
 
 
 class ManagedGroupAdapter(BaseManagedGroupAdapter):

--- a/gregor_django/gregor_anvil/tests/test_adapters.py
+++ b/gregor_django/gregor_anvil/tests/test_adapters.py
@@ -1,8 +1,15 @@
 import responses
 from anvil_consortium_manager.adapters.default import DefaultWorkspaceAdapter
-from anvil_consortium_manager.models import Account, GroupGroupMembership, WorkspaceGroupSharing
+from anvil_consortium_manager.anvil_api import AnVILAPIError
+from anvil_consortium_manager.models import (
+    Account,
+    GroupAccountMembership,
+    GroupGroupMembership,
+    WorkspaceGroupSharing,
+)
 from anvil_consortium_manager.tests.factories import (
     AccountFactory,
+    GroupAccountMembershipFactory,
     ManagedGroupFactory,
     WorkspaceFactory,
     WorkspaceGroupSharingFactory,
@@ -10,12 +17,16 @@ from anvil_consortium_manager.tests.factories import (
 from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
 from django.test import TestCase, override_settings
 
+from gregor_django.gregor_anvil.tests.factories import (
+    PartnerGroupFactory,
+    ResearchCenterFactory,
+)
 from gregor_django.users.tests.factories import UserFactory
 
 from .. import adapters
 
 
-class AccountAdapterTest(TestCase):
+class AccountAdapterTest(AnVILAPIMockTestMixin, TestCase):
     """Tests of the AccountAdapter, where not tested in other TestCases."""
 
     def test_get_autocomplete_label_linked_user(self):
@@ -65,6 +76,236 @@ class AccountAdapterTest(TestCase):
         self.assertEqual(len(queryset), 1)
         self.assertIn(account_1, queryset)
         self.assertNotIn(account_2, queryset)
+
+    def test_after_account_verification_no_groups(self):
+        ResearchCenterFactory.create(member_group=ManagedGroupFactory.create())
+        PartnerGroupFactory.create(member_group=ManagedGroupFactory.create())
+        # Create an account not linked to the above RC or group.
+        account = AccountFactory.create(verified=True)
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 0)
+
+    def test_after_account_verification_one_rc(self):
+        member_group = ManagedGroupFactory.create()
+        research_center = ResearchCenterFactory.create(member_group=member_group)
+        # Create an account whose user is linked to this RC.
+        user = UserFactory.create()
+        user.research_centers.add(research_center)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for RC membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group.name}/member/{account.email}",
+            status=204,
+        )
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 1)
+        membership = GroupAccountMembership.objects.first()
+        self.assertEqual(membership.group, member_group)
+        self.assertEqual(membership.account, account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+
+    def test_after_account_verification_two_rcs(self):
+        # Create an account whose user is linked to two RCs.
+        user = UserFactory.create()
+        member_group_1 = ManagedGroupFactory.create()
+        research_center_1 = ResearchCenterFactory.create(member_group=member_group_1)
+        user.research_centers.add(research_center_1)
+        member_group_2 = ManagedGroupFactory.create()
+        research_center_2 = ResearchCenterFactory.create(member_group=member_group_2)
+        user.research_centers.add(research_center_2)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for RC membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_1.name}/member/{account.email}",
+            status=204,
+        )
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_2.name}/member/{account.email}",
+            status=204,
+        )
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 2)
+        membership = GroupAccountMembership.objects.get(group=member_group_1, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+        membership = GroupAccountMembership.objects.get(group=member_group_2, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+
+    def test_after_account_verification_one_rc_no_members_group(self):
+        """A user is linked to an RC with no members group."""
+        user = UserFactory.create()
+        research_center = ResearchCenterFactory.create(member_group=None)
+        user.research_centers.add(research_center)
+        account = AccountFactory.create(user=user, verified=True)
+        # No mocked API responses.
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 0)
+
+    def test_after_account_verification_one_rc_api_error(self):
+        member_group = ManagedGroupFactory.create()
+        research_center = ResearchCenterFactory.create(member_group=member_group)
+        # Create an account whose user is linked to this RC.
+        user = UserFactory.create()
+        user.research_centers.add(research_center)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for RC membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group.name}/member/{account.email}",
+            status=500,
+            json={"message": "test error"},
+        )
+        # Run the adapter method.
+        with self.assertRaises(AnVILAPIError):
+            adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        # Saved but not created on AnVIL.
+        self.assertEqual(GroupAccountMembership.objects.count(), 1)
+
+    def test_after_account_verification_one_partner(self):
+        member_group = ManagedGroupFactory.create()
+        partner_group = PartnerGroupFactory.create(member_group=member_group)
+        # Create an account whose user is linked to this partner group.
+        user = UserFactory.create()
+        user.partner_groups.add(partner_group)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for RC membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group.name}/member/{account.email}",
+            status=204,
+        )
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 1)
+        membership = GroupAccountMembership.objects.first()
+        self.assertEqual(membership.group, member_group)
+        self.assertEqual(membership.account, account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+
+    def test_after_account_verification_two_partners(self):
+        user = UserFactory.create()
+        member_group_1 = ManagedGroupFactory.create()
+        partner_group_1 = PartnerGroupFactory.create(member_group=member_group_1)
+        user.partner_groups.add(partner_group_1)
+        member_group_2 = ManagedGroupFactory.create()
+        partner_group_2 = PartnerGroupFactory.create(member_group=member_group_2)
+        user.partner_groups.add(partner_group_2)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for RC membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_1.name}/member/{account.email}",
+            status=204,
+        )
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_2.name}/member/{account.email}",
+            status=204,
+        )
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 2)
+        membership = GroupAccountMembership.objects.get(group=member_group_1, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+        membership = GroupAccountMembership.objects.get(group=member_group_2, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+
+    def test_after_account_verification_one_partner_no_members_group(self):
+        """A user is linked to a PartnerGroup with no members group."""
+        user = UserFactory.create()
+        partner_group = PartnerGroupFactory.create(member_group=None)
+        user.partner_groups.add(partner_group)
+        account = AccountFactory.create(user=user, verified=True)
+        # No mocked API responses.
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 0)
+
+    def test_after_account_verification_one_partner_group_api_error(self):
+        member_group = ManagedGroupFactory.create()
+        partner_group = PartnerGroupFactory.create(member_group=member_group)
+        # Create an account whose user is linked to this RC.
+        user = UserFactory.create()
+        user.partner_groups.add(partner_group)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for RC membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group.name}/member/{account.email}",
+            status=500,
+            json={"message": "test error"},
+        )
+        # Run the adapter method.
+        with self.assertRaises(AnVILAPIError):
+            adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        # Saved but not created on AnVIL.
+        self.assertEqual(GroupAccountMembership.objects.count(), 1)
+
+    def test_after_account_verification_one_rc_and_one_partner_group(self):
+        user = UserFactory.create()
+        member_group_1 = ManagedGroupFactory.create()
+        partner_group = PartnerGroupFactory.create(member_group=member_group_1)
+        user.partner_groups.add(partner_group)
+        member_group_2 = ManagedGroupFactory.create()
+        research_center = ResearchCenterFactory.create(member_group=member_group_2)
+        user.research_centers.add(research_center)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for RC membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_1.name}/member/{account.email}",
+            status=204,
+        )
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_2.name}/member/{account.email}",
+            status=204,
+        )
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 2)
+        membership = GroupAccountMembership.objects.get(group=member_group_1, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+        membership = GroupAccountMembership.objects.get(group=member_group_2, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+
+    def test_after_account_verification_group_account_membership_already_exists(self):
+        member_group = ManagedGroupFactory.create()
+        research_center = ResearchCenterFactory.create(member_group=member_group)
+        # Create an account whose user is linked to this RC.
+        user = UserFactory.create()
+        user.research_centers.add(research_center)
+        account = AccountFactory.create(user=user, verified=True)
+        # Create the group-account membership already.
+        GroupAccountMembershipFactory.create(
+            group=member_group,
+            account=account,
+            role=GroupGroupMembership.ADMIN,
+        )
+        # No API response - group will not be changed.
+        # Run the adapter method.
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 1)
+        membership = GroupAccountMembership.objects.first()
+        self.assertEqual(membership.group, member_group)
+        self.assertEqual(membership.account, account)
+        self.assertEqual(membership.role, GroupGroupMembership.ADMIN)
 
 
 class WorkspaceAdminSharingAdapterMixin(AnVILAPIMockTestMixin, TestCase):

--- a/gregor_django/gregor_anvil/tests/test_adapters.py
+++ b/gregor_django/gregor_anvil/tests/test_adapters.py
@@ -15,6 +15,7 @@ from anvil_consortium_manager.tests.factories import (
     WorkspaceGroupSharingFactory,
 )
 from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
+from django.core import mail
 from django.test import TestCase, override_settings
 
 from gregor_django.gregor_anvil.tests.factories import (
@@ -306,6 +307,41 @@ class AccountAdapterTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(membership.group, member_group)
         self.assertEqual(membership.account, account)
         self.assertEqual(membership.role, GroupGroupMembership.ADMIN)
+
+    def test_get_account_verification_notification_context(self):
+        account = AccountFactory.create(verified=True)
+        context = adapters.AccountAdapter().get_account_verification_notification_context(account)
+        self.assertEqual(context["email"], account.email)
+        self.assertEqual(context["user"], account.user)
+        self.assertIn("memberships", context)
+        self.assertEqual(len(context["memberships"]), 0)
+        # One membership
+        membership_1 = GroupAccountMembershipFactory.create(account=account)
+        context = adapters.AccountAdapter().get_account_verification_notification_context(account)
+        self.assertEqual(len(context["memberships"]), 1)
+        self.assertIn(membership_1, context["memberships"])
+        # Two memberships
+        membership_2 = GroupAccountMembershipFactory.create(account=account)
+        context = adapters.AccountAdapter().get_account_verification_notification_context(account)
+        self.assertEqual(len(context["memberships"]), 2)
+        self.assertIn(membership_1, context["memberships"])
+        self.assertIn(membership_2, context["memberships"])
+
+    def test_send_account_verification_notification_email_includes_memberships(self):
+        """The account verification notification email includes a list of the account memberships."""
+        account = AccountFactory.create(verified=True)
+        membership = GroupAccountMembershipFactory.create(account=account)
+        with self.assertTemplateUsed("gregor_anvil/account_notification_email.html"):
+            adapters.AccountAdapter().send_account_verification_notification_email(account)
+        # Check that the email was sent.
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        # Check that the email contains the account email.
+        self.assertIn(account.email, email.body)
+        # Check that the email contains the username
+        self.assertIn(account.user.username, email.body)
+        # Check that the email contains the membership info.
+        self.assertIn(str(membership), email.body)
 
 
 class WorkspaceAdminSharingAdapterMixin(AnVILAPIMockTestMixin, TestCase):

--- a/gregor_django/templates/gregor_anvil/account_notification_email.html
+++ b/gregor_django/templates/gregor_anvil/account_notification_email.html
@@ -1,0 +1,12 @@
+{% extends "anvil_consortium_manager/account_notification_email.html" %}
+
+{% block extra_content %}
+
+Group memberships:
+<ul>
+    {% for membership in memberships %}
+        <li>{{ membership }}</li>
+    {% endfor %}
+</ul>
+
+{% endblock extra_content %}


### PR DESCRIPTION
- Use the new AccountAdapter functionality to automatically add a user to their RC or partner group  group(s) fo rmembers after they link their account.
- Show the list of groups that an Account belongs to in the account verification notification email to the DCC