### PR TITLE
Show a question mark icon when the app can't determine consortium access

### DIFF
--- a/gregor_django/gregor_anvil/tables.py
+++ b/gregor_django/gregor_anvil/tables.py
@@ -1,5 +1,8 @@
 import django_tables2 as tables
 from anvil_consortium_manager.adapters.workspace import workspace_adapter_registry
+from anvil_consortium_manager.exceptions import (
+    WorkspaceAccessAuthorizationDomainUnknownError,
+)
 from anvil_consortium_manager.models import Account, ManagedGroup, Workspace
 from django.utils.html import format_html
 
@@ -156,11 +159,24 @@ class WorkspaceConsortiumAccessTable(tables.Table):
         except ManagedGroup.DoesNotExist:
             has_consortium_access = False
         else:
-            has_consortium_access = record.has_group_in_authorization_domain(group) and record.is_shared_with_group(
-                group
-            )
+            try:
+                has_consortium_access = record.has_group_in_authorization_domain(group) and record.is_shared_with_group(
+                    group
+                )
+            except WorkspaceAccessAuthorizationDomainUnknownError:
+                has_consortium_access = None
 
-        if has_consortium_access:
+        if has_consortium_access is None:
+            icon = "question-circle-fill"
+            color = "#F5B027"
+            tooltip = "App does not manage this workspace and/or its auth domain"
+            value = format_html(
+                """<i class="bi bi-{}" data-bs-toggle="tooltip" data-bs-placement="top" title="{}" style="color: {};"></i>""",  # noqa: E501
+                icon,
+                tooltip,
+                color,
+            )
+        elif has_consortium_access:
             icon = "check-circle-fill"
             color = "green"
             value = format_html(

--- a/gregor_django/gregor_anvil/tests/test_tables.py
+++ b/gregor_django/gregor_anvil/tests/test_tables.py
@@ -267,6 +267,15 @@ class WorkspaceConsortiumAccessTableTest(TestCase):
         table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
         self.assertNotIn("check-circle-fill", table.render_consortium_access(workspace))
 
+    def test_is_shared_one_auth_domain_not_managed_by_app(self):
+        """GREGOR_ALL is in auth domain, auth domain is not managed by the app, and workspace is shared."""
+        workspace = WorkspaceFactory.create()
+        auth_domain = WorkspaceAuthorizationDomainFactory.create(workspace=workspace, group__is_managed_by_app=False)
+        GroupGroupMembershipFactory.create(parent_group=auth_domain.group, child_group=self.gregor_all)
+        WorkspaceGroupSharingFactory.create(workspace=workspace, group=self.gregor_all)
+        table = tables.WorkspaceConsortiumAccessTable(Workspace.objects.all())
+        self.assertIn("question-circle-fill", table.render_consortium_access(workspace))
+
 
 class DefaultWorkspaceTableTest(TestCase):
     model = Workspace


### PR DESCRIPTION
When a workspace has an auth domain that is not managed by the app, show a question mark icon in the WorkspaceConsortiumAccessTable. Previously the code was not catching an exception, causing an internal server error when trying to load the table for workspaces that had an auth domain not managed by the app.